### PR TITLE
GEN-663 sklearn bump to 1.0.X

### DIFF
--- a/genra/rax/skl/cls.py
+++ b/genra/rax/skl/cls.py
@@ -9,10 +9,8 @@ Adapted from sklearn.neighbors.KNeighborsClassifier
 
 import numpy as np
 import sklearn
-from sklearn.base import ClassifierMixin
-from sklearn.neighbors._base import BaseEstimator, NeighborsBase,\
-        KNeighborsMixin, SupervisedIntegerMixin,\
-        _check_weights, _get_weights
+from sklearn.neighbors import KNeighborsClassifier
+from sklearn.neighbors._base import _check_weights, _get_weights
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted,_is_arraylike, _num_samples
 from sklearn.utils.multiclass import unique_labels
 from scipy import stats
@@ -20,8 +18,7 @@ from sklearn.utils.extmath import weighted_mode
 
 import warnings
 
-class GenRAPredClass(NeighborsBase, KNeighborsMixin,
-                     SupervisedIntegerMixin, ClassifierMixin):
+class GenRAPredClass(KNeighborsClassifier):
     """GenRA Classifier implementing the k-nearest neighbors vote.
 
     Parameters

--- a/genra/rax/skl/reg.py
+++ b/genra/rax/skl/reg.py
@@ -9,10 +9,8 @@ Adapted from sklearn.neighbors.KNeighborsRegressor
 
 import numpy as np
 import sklearn
-from sklearn.base import RegressorMixin
-from sklearn.neighbors._base import BaseEstimator, NeighborsBase,\
-        KNeighborsMixin, SupervisedIntegerMixin,SupervisedFloatMixin,\
-        _check_weights, _get_weights
+from sklearn.neighbors import KNeighborsRegressor
+from sklearn.neighbors._base import _check_weights, _get_weights
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted,_is_arraylike, _num_samples
 from sklearn.utils.multiclass import unique_labels
 from scipy import stats
@@ -20,10 +18,7 @@ from sklearn.utils.extmath import weighted_mode
 
 import warnings
 
-class GenRAPredValue(NeighborsBase, 
-                     KNeighborsMixin,
-                     SupervisedFloatMixin,
-                     RegressorMixin):
+class GenRAPredValue(KNeighborsRegressor):
     """GenRA Value Prediction based on k-nearest neighbors.
 
     The target is predicted by local interpolation of the targets

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ ipykernel==5.1.4
 ipython==7.13.0
 ipython-genutils==0.2.0
 jedi==0.16.0
-joblib==0.14.1
+joblib==1.1.0
 jupyter-client==6.1.2
 jupyter-core==4.6.3
 kiwisolver==1.2.0
@@ -19,7 +19,7 @@ mkl-fft==1.0.15
 mkl-random==1.1.0
 mkl-service==2.3.0
 mongoengine==0.19.1
-numpy==1.18.1
+numpy==1.22.1
 olefile==0.46
 pandas==1.0.3
 parso==0.6.2
@@ -40,10 +40,11 @@ pytz==2019.3
 pyzmq==18.1.1
 ruamel.yaml==0.16.10
 ruamel.yaml.clib==0.2.0
-scikit-learn==0.22.1
-scipy==1.4.1
+scikit-learn==1.0.1
+scipy==1.7.3
 seaborn==0.10.0
 six==1.14.0
+threadpoolctl==3.1.0
 toml==0.10.0
 tornado==6.0.4
 traitlets==4.3.3

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='genra',
     packages=find_packages(),
     version='0.1.3',
-    install_requires=['numpy', 'scipy', 'scikit-learn==0.22.1', 'lxml'],
+    install_requires=['numpy', 'scipy', 'scikit-learn==1.0.1', 'lxml'],
     description='Generalised Read Across (GenRA) in Python',
     author='Imran Shah',
     license='MIT',

--- a/src/genra/rax/skl/cls.py
+++ b/src/genra/rax/skl/cls.py
@@ -9,10 +9,8 @@ Adapted from sklearn.neighbors.KNeighborsClassifier
 
 import numpy as np
 import sklearn
-from sklearn.base import ClassifierMixin
-from sklearn.neighbors._base import BaseEstimator, NeighborsBase,\
-        KNeighborsMixin, SupervisedIntegerMixin,\
-        _check_weights, _get_weights
+from sklearn.neighbors import KNeighborsClassifier
+from sklearn.neighbors._base import _check_weights, _get_weights
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted,_is_arraylike, _num_samples
 from sklearn.utils.multiclass import unique_labels
 from scipy import stats
@@ -20,8 +18,7 @@ from sklearn.utils.extmath import weighted_mode
 
 import warnings
 
-class GenRAPredClass(NeighborsBase, KNeighborsMixin,
-                     SupervisedIntegerMixin, ClassifierMixin):
+class GenRAPredClass(KNeighborsClassifier):
     """GenRA Classifier implementing the k-nearest neighbors vote.
 
     Parameters

--- a/src/genra/rax/skl/reg.py
+++ b/src/genra/rax/skl/reg.py
@@ -9,10 +9,8 @@ Adapted from sklearn.neighbors.KNeighborsRegressor
 
 import numpy as np
 import sklearn
-from sklearn.base import RegressorMixin
-from sklearn.neighbors._base import BaseEstimator, NeighborsBase,\
-        KNeighborsMixin, SupervisedIntegerMixin,SupervisedFloatMixin,\
-        _check_weights, _get_weights
+from sklearn.neighbors import KNeighborsRegressor
+from sklearn.neighbors._base import _check_weights, _get_weights
 from sklearn.utils.validation import check_X_y, check_array, check_is_fitted,_is_arraylike, _num_samples
 from sklearn.utils.multiclass import unique_labels
 from scipy import stats
@@ -20,10 +18,7 @@ from sklearn.utils.extmath import weighted_mode
 
 import warnings
 
-class GenRAPredValue(NeighborsBase, 
-                     KNeighborsMixin,
-                     SupervisedFloatMixin,
-                     RegressorMixin):
+class GenRAPredValue(KNeighborsRegressor):
     """GenRA Value Prediction based on k-nearest neighbors.
 
     The target is predicted by local interpolation of the targets


### PR DESCRIPTION
The main change for `GenRAPredClass` and `GenRAPredValue` is that the mixins/parent classes that they inherited were replaced (entirely) by `KNeighborsClassifier` and `KNeighborsRegressor`, respectively.

Notes:
- `NeighborsBase` and `KNeighborsMixin` that used to be inherited by the two classes are inherited by `KNeighborsClassifier` / `KNeighborsRegressor` in 1.0.1
- `ClassifierMixin` that used to be inherited by `GenRAPredClass` already imported from KNeighborsClassifier in 1.0.1
- `RegressorMixin` that used to be inherited by `GenRAPredValue` already imported from KNeighborsRegressor in 1.0.1
- `SupervisedIntegerMixin` => This got removed in `sklearn==1.0.1`. (However, in `sklearn==0.22.X` this mixin used to be imported by `KNeighborsClassifier`)
- `SupervisedFloatMixin` => This got removed in `sklearn==1.0.1`. (However, in `sklearn==0.22.X` this mixin used to be imported by `KNeighborsRegressor`,)
- The documentation on 1.0.1 mainly noted adjustments to warnings and errors in the `neighbors` module, on https://scikit-learn.org/stable/whats_new/v1.0.html#changes-1-0


Other notes:
Three packages listed on `requirements.txt` were un-installable locally:
```
mkl-fft==1.0.15
mkl-random==1.1.0
mkl-service==2.3.0
```