### PR TITLE
Correct similarity selection

### DIFF
--- a/genra/rax/skl/reg.py
+++ b/genra/rax/skl/reg.py
@@ -148,7 +148,7 @@ class GenRAPredValue(KNeighborsRegressor):
 
         denom=np.sum(neigh_sim, axis=1)
         for j in range(_y.shape[1]):
-            num = np.sum(_y[neigh_ind, j] * neigh_sim[j], axis=1)
+            num = np.sum(_y[neigh_ind, j] * neigh_sim, axis=1)
             y_pred[:, j] = num / denom
 
         if self._y.ndim == 1:

--- a/genra/rax/skl/reg.py
+++ b/genra/rax/skl/reg.py
@@ -146,8 +146,8 @@ class GenRAPredValue(KNeighborsRegressor):
 
         y_pred = np.empty((X.shape[0], _y.shape[1]), dtype=np.float64)
 
+        denom=np.sum(neigh_sim, axis=1)
         for j in range(_y.shape[1]):
-            denom=np.sum(neigh_sim[j])
             num = np.sum(_y[neigh_ind, j] * neigh_sim[j], axis=1)
             y_pred[:, j] = num / denom
 

--- a/notebooks/misc/example_j_index_error.ipynb
+++ b/notebooks/misc/example_j_index_error.ipynb
@@ -1,1872 +1,1009 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "cb0b680d-9c0f-4872-892b-df3fb3b4b66d",
+   "metadata": {},
+   "source": [
+    "## The problem:\n",
+    "\n",
+    "In `GenRAPredValue.predict(...)` method, `denom=np.sum(neigh_sim[j])` takes the sum of similarities across all neighbors for query point `j`. However, `j` represents the index of outputs - i.e., `j` will be within `range(n_outputs)` - and shouldn't be used as index to identify a query point. \n",
+    "\n",
+    "Issues:\n",
+    "- If `n_outputs==1` (which it may often be), but `n_queries>1`, the prediction for all query points not in index=0 were likely miscalculated, since the wrong denominator was used\n",
+    "- This also errors out if `n_outputs>n_neighbors`, which is demonstrated below in this notebook\n",
+    "```nom"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df7834d5-d3c5-4a9e-bbb0-ff8abbae8fd5",
+   "metadata": {},
+   "source": [
+    "## The proposed solution\n",
+    "\n",
+    "Setting `denom=np.sum(neigh_sim, axis=1)` outside the forloop.\n",
+    "\n",
+    "Note that `denom` is now an array of floats (as opposed to a float). Since `denom.shape == num.shape` (more specifically `shape=(n_queries,)`), the operation `num / denom` becomes an element wise operation where numerator is still the regressand and the numerator is each query point's respective sum of similarities."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eade2668-64b5-4f9d-b336-b14b4678d504",
+   "metadata": {},
+   "source": [
+    "### Example of error\n",
+    "\n",
+    "Because `j` represents the index of output, but in the old code gets treated as index of query point, we can construct an example where `n_neighbors>n_outputs` and see the `predict` method error out.\n",
+    "\n",
+    "Dimensions:\n",
+    "```\n",
+    "n_samples=100\n",
+    "n_features=1000\n",
+    "n_outputs=50\n",
+    "n_queries=1\n",
+    "n_neighbors=8\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "86ceb649-529a-4f4b-a3c2-4e98c7888608",
+   "execution_count": 19,
+   "id": "5dda1939-d6c8-4f8e-b019-4b410f6b13d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from genra.rax.skl.reg import GenRAPredValue\n",
+    "# scikit example to see how it should behave\n",
+    "from sklearn.neighbors import KNeighborsRegressor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "587d456b-7394-4c7f-8a4c-3d781744573f",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "      <th>1</th>\n",
+       "      <th>2</th>\n",
+       "      <th>3</th>\n",
+       "      <th>4</th>\n",
+       "      <th>5</th>\n",
+       "      <th>6</th>\n",
+       "      <th>7</th>\n",
+       "      <th>8</th>\n",
+       "      <th>9</th>\n",
+       "      <th>...</th>\n",
+       "      <th>990</th>\n",
+       "      <th>991</th>\n",
+       "      <th>992</th>\n",
+       "      <th>993</th>\n",
+       "      <th>994</th>\n",
+       "      <th>995</th>\n",
+       "      <th>996</th>\n",
+       "      <th>997</th>\n",
+       "      <th>998</th>\n",
+       "      <th>999</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>95</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>96</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>97</th>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>98</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99</th>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>100 rows × 1000 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    0    1    2    3    4    5    6    7    8    9    ...  990  991  992  993  \\\n",
+       "0     0    0    1    1    1    1    1    0    0    1  ...    0    0    1    0   \n",
+       "1     0    1    1    0    0    0    1    0    1    0  ...    1    0    0    0   \n",
+       "2     1    0    0    1    0    1    1    1    0    0  ...    1    1    1    0   \n",
+       "3     0    0    1    1    0    0    0    0    0    0  ...    0    1    1    0   \n",
+       "4     0    1    1    0    1    1    1    1    0    1  ...    1    0    1    0   \n",
+       "..  ...  ...  ...  ...  ...  ...  ...  ...  ...  ...  ...  ...  ...  ...  ...   \n",
+       "95    1    1    0    0    1    1    1    0    1    0  ...    1    1    1    0   \n",
+       "96    1    1    1    1    1    0    0    0    1    0  ...    0    0    0    0   \n",
+       "97    1    0    1    1    1    0    0    1    0    0  ...    0    0    1    1   \n",
+       "98    1    1    1    0    0    0    0    0    1    0  ...    1    0    1    0   \n",
+       "99    1    0    0    1    1    0    0    1    0    0  ...    0    1    0    1   \n",
+       "\n",
+       "    994  995  996  997  998  999  \n",
+       "0     1    1    1    0    1    0  \n",
+       "1     1    0    1    1    0    0  \n",
+       "2     0    0    0    1    1    0  \n",
+       "3     1    0    1    0    1    0  \n",
+       "4     0    0    1    1    1    1  \n",
+       "..  ...  ...  ...  ...  ...  ...  \n",
+       "95    0    0    1    1    0    1  \n",
+       "96    1    0    0    0    1    0  \n",
+       "97    1    1    1    0    0    1  \n",
+       "98    1    0    1    0    0    0  \n",
+       "99    0    0    1    0    1    1  \n",
+       "\n",
+       "[100 rows x 1000 columns]"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# random binary matrix of size 100 x 1000 (n_samples, n_features)\n",
+    "sample_X = pd.DataFrame(np.random.randint(0,2, size=(100, 1000)))\n",
+    "sample_X"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "da85635b-bcb5-4703-a7aa-79038e6b54eb",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "      <th>1</th>\n",
+       "      <th>2</th>\n",
+       "      <th>3</th>\n",
+       "      <th>4</th>\n",
+       "      <th>5</th>\n",
+       "      <th>6</th>\n",
+       "      <th>7</th>\n",
+       "      <th>8</th>\n",
+       "      <th>9</th>\n",
+       "      <th>...</th>\n",
+       "      <th>40</th>\n",
+       "      <th>41</th>\n",
+       "      <th>42</th>\n",
+       "      <th>43</th>\n",
+       "      <th>44</th>\n",
+       "      <th>45</th>\n",
+       "      <th>46</th>\n",
+       "      <th>47</th>\n",
+       "      <th>48</th>\n",
+       "      <th>49</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.452114</td>\n",
+       "      <td>0.032065</td>\n",
+       "      <td>0.364285</td>\n",
+       "      <td>0.392233</td>\n",
+       "      <td>0.355917</td>\n",
+       "      <td>0.595651</td>\n",
+       "      <td>0.895717</td>\n",
+       "      <td>0.999875</td>\n",
+       "      <td>0.908490</td>\n",
+       "      <td>0.750081</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.378443</td>\n",
+       "      <td>0.214993</td>\n",
+       "      <td>0.869864</td>\n",
+       "      <td>0.967591</td>\n",
+       "      <td>0.568308</td>\n",
+       "      <td>0.373858</td>\n",
+       "      <td>0.238336</td>\n",
+       "      <td>0.336907</td>\n",
+       "      <td>0.735189</td>\n",
+       "      <td>0.208528</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.616368</td>\n",
+       "      <td>0.446414</td>\n",
+       "      <td>0.124196</td>\n",
+       "      <td>0.881161</td>\n",
+       "      <td>0.706904</td>\n",
+       "      <td>0.169106</td>\n",
+       "      <td>0.506948</td>\n",
+       "      <td>0.810981</td>\n",
+       "      <td>0.273023</td>\n",
+       "      <td>0.128275</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.840553</td>\n",
+       "      <td>0.231098</td>\n",
+       "      <td>0.585147</td>\n",
+       "      <td>0.181303</td>\n",
+       "      <td>0.110416</td>\n",
+       "      <td>0.392077</td>\n",
+       "      <td>0.189333</td>\n",
+       "      <td>0.950604</td>\n",
+       "      <td>0.306619</td>\n",
+       "      <td>0.667940</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.357270</td>\n",
+       "      <td>0.308349</td>\n",
+       "      <td>0.321027</td>\n",
+       "      <td>0.248440</td>\n",
+       "      <td>0.029853</td>\n",
+       "      <td>0.167774</td>\n",
+       "      <td>0.781586</td>\n",
+       "      <td>0.860615</td>\n",
+       "      <td>0.143878</td>\n",
+       "      <td>0.240694</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.223928</td>\n",
+       "      <td>0.458134</td>\n",
+       "      <td>0.206307</td>\n",
+       "      <td>0.563044</td>\n",
+       "      <td>0.053622</td>\n",
+       "      <td>0.775777</td>\n",
+       "      <td>0.337353</td>\n",
+       "      <td>0.908520</td>\n",
+       "      <td>0.082054</td>\n",
+       "      <td>0.859696</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0.004180</td>\n",
+       "      <td>0.812562</td>\n",
+       "      <td>0.388201</td>\n",
+       "      <td>0.263393</td>\n",
+       "      <td>0.212413</td>\n",
+       "      <td>0.266511</td>\n",
+       "      <td>0.915072</td>\n",
+       "      <td>0.101571</td>\n",
+       "      <td>0.974111</td>\n",
+       "      <td>0.359393</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.739699</td>\n",
+       "      <td>0.882037</td>\n",
+       "      <td>0.236231</td>\n",
+       "      <td>0.997473</td>\n",
+       "      <td>0.652169</td>\n",
+       "      <td>0.554754</td>\n",
+       "      <td>0.541816</td>\n",
+       "      <td>0.492460</td>\n",
+       "      <td>0.231477</td>\n",
+       "      <td>0.597966</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.176012</td>\n",
+       "      <td>0.659479</td>\n",
+       "      <td>0.976982</td>\n",
+       "      <td>0.801375</td>\n",
+       "      <td>0.272097</td>\n",
+       "      <td>0.339287</td>\n",
+       "      <td>0.992800</td>\n",
+       "      <td>0.085688</td>\n",
+       "      <td>0.036562</td>\n",
+       "      <td>0.709115</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.935800</td>\n",
+       "      <td>0.803035</td>\n",
+       "      <td>0.869046</td>\n",
+       "      <td>0.335666</td>\n",
+       "      <td>0.691991</td>\n",
+       "      <td>0.576968</td>\n",
+       "      <td>0.801276</td>\n",
+       "      <td>0.129568</td>\n",
+       "      <td>0.670519</td>\n",
+       "      <td>0.744683</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>95</th>\n",
+       "      <td>0.458014</td>\n",
+       "      <td>0.303171</td>\n",
+       "      <td>0.799521</td>\n",
+       "      <td>0.959182</td>\n",
+       "      <td>0.586324</td>\n",
+       "      <td>0.834933</td>\n",
+       "      <td>0.888921</td>\n",
+       "      <td>0.592514</td>\n",
+       "      <td>0.105495</td>\n",
+       "      <td>0.291447</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.807293</td>\n",
+       "      <td>0.796751</td>\n",
+       "      <td>0.707114</td>\n",
+       "      <td>0.830545</td>\n",
+       "      <td>0.087533</td>\n",
+       "      <td>0.651908</td>\n",
+       "      <td>0.911708</td>\n",
+       "      <td>0.725931</td>\n",
+       "      <td>0.811368</td>\n",
+       "      <td>0.051370</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>96</th>\n",
+       "      <td>0.014264</td>\n",
+       "      <td>0.289107</td>\n",
+       "      <td>0.810863</td>\n",
+       "      <td>0.279296</td>\n",
+       "      <td>0.170788</td>\n",
+       "      <td>0.932949</td>\n",
+       "      <td>0.073788</td>\n",
+       "      <td>0.105420</td>\n",
+       "      <td>0.627173</td>\n",
+       "      <td>0.133664</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.809498</td>\n",
+       "      <td>0.052013</td>\n",
+       "      <td>0.589336</td>\n",
+       "      <td>0.177479</td>\n",
+       "      <td>0.477017</td>\n",
+       "      <td>0.122964</td>\n",
+       "      <td>0.743014</td>\n",
+       "      <td>0.056588</td>\n",
+       "      <td>0.223094</td>\n",
+       "      <td>0.356025</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>97</th>\n",
+       "      <td>0.717929</td>\n",
+       "      <td>0.138155</td>\n",
+       "      <td>0.260905</td>\n",
+       "      <td>0.680843</td>\n",
+       "      <td>0.881228</td>\n",
+       "      <td>0.830034</td>\n",
+       "      <td>0.587989</td>\n",
+       "      <td>0.766219</td>\n",
+       "      <td>0.200880</td>\n",
+       "      <td>0.660416</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.940266</td>\n",
+       "      <td>0.590460</td>\n",
+       "      <td>0.067708</td>\n",
+       "      <td>0.194836</td>\n",
+       "      <td>0.368581</td>\n",
+       "      <td>0.667281</td>\n",
+       "      <td>0.577572</td>\n",
+       "      <td>0.915061</td>\n",
+       "      <td>0.072751</td>\n",
+       "      <td>0.537982</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>98</th>\n",
+       "      <td>0.935746</td>\n",
+       "      <td>0.767309</td>\n",
+       "      <td>0.999281</td>\n",
+       "      <td>0.337977</td>\n",
+       "      <td>0.635719</td>\n",
+       "      <td>0.988403</td>\n",
+       "      <td>0.606621</td>\n",
+       "      <td>0.691682</td>\n",
+       "      <td>0.958037</td>\n",
+       "      <td>0.812429</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.187976</td>\n",
+       "      <td>0.736116</td>\n",
+       "      <td>0.563236</td>\n",
+       "      <td>0.616845</td>\n",
+       "      <td>0.647653</td>\n",
+       "      <td>0.793831</td>\n",
+       "      <td>0.414686</td>\n",
+       "      <td>0.844797</td>\n",
+       "      <td>0.058041</td>\n",
+       "      <td>0.288947</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>99</th>\n",
+       "      <td>0.452165</td>\n",
+       "      <td>0.356679</td>\n",
+       "      <td>0.351935</td>\n",
+       "      <td>0.277445</td>\n",
+       "      <td>0.200104</td>\n",
+       "      <td>0.488462</td>\n",
+       "      <td>0.092656</td>\n",
+       "      <td>0.429745</td>\n",
+       "      <td>0.336086</td>\n",
+       "      <td>0.958630</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.850513</td>\n",
+       "      <td>0.957661</td>\n",
+       "      <td>0.862673</td>\n",
+       "      <td>0.757084</td>\n",
+       "      <td>0.791210</td>\n",
+       "      <td>0.927126</td>\n",
+       "      <td>0.218500</td>\n",
+       "      <td>0.859196</td>\n",
+       "      <td>0.628123</td>\n",
+       "      <td>0.843056</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>100 rows × 50 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          0         1         2         3         4         5         6   \\\n",
+       "0   0.452114  0.032065  0.364285  0.392233  0.355917  0.595651  0.895717   \n",
+       "1   0.616368  0.446414  0.124196  0.881161  0.706904  0.169106  0.506948   \n",
+       "2   0.357270  0.308349  0.321027  0.248440  0.029853  0.167774  0.781586   \n",
+       "3   0.004180  0.812562  0.388201  0.263393  0.212413  0.266511  0.915072   \n",
+       "4   0.176012  0.659479  0.976982  0.801375  0.272097  0.339287  0.992800   \n",
+       "..       ...       ...       ...       ...       ...       ...       ...   \n",
+       "95  0.458014  0.303171  0.799521  0.959182  0.586324  0.834933  0.888921   \n",
+       "96  0.014264  0.289107  0.810863  0.279296  0.170788  0.932949  0.073788   \n",
+       "97  0.717929  0.138155  0.260905  0.680843  0.881228  0.830034  0.587989   \n",
+       "98  0.935746  0.767309  0.999281  0.337977  0.635719  0.988403  0.606621   \n",
+       "99  0.452165  0.356679  0.351935  0.277445  0.200104  0.488462  0.092656   \n",
+       "\n",
+       "          7         8         9   ...        40        41        42        43  \\\n",
+       "0   0.999875  0.908490  0.750081  ...  0.378443  0.214993  0.869864  0.967591   \n",
+       "1   0.810981  0.273023  0.128275  ...  0.840553  0.231098  0.585147  0.181303   \n",
+       "2   0.860615  0.143878  0.240694  ...  0.223928  0.458134  0.206307  0.563044   \n",
+       "3   0.101571  0.974111  0.359393  ...  0.739699  0.882037  0.236231  0.997473   \n",
+       "4   0.085688  0.036562  0.709115  ...  0.935800  0.803035  0.869046  0.335666   \n",
+       "..       ...       ...       ...  ...       ...       ...       ...       ...   \n",
+       "95  0.592514  0.105495  0.291447  ...  0.807293  0.796751  0.707114  0.830545   \n",
+       "96  0.105420  0.627173  0.133664  ...  0.809498  0.052013  0.589336  0.177479   \n",
+       "97  0.766219  0.200880  0.660416  ...  0.940266  0.590460  0.067708  0.194836   \n",
+       "98  0.691682  0.958037  0.812429  ...  0.187976  0.736116  0.563236  0.616845   \n",
+       "99  0.429745  0.336086  0.958630  ...  0.850513  0.957661  0.862673  0.757084   \n",
+       "\n",
+       "          44        45        46        47        48        49  \n",
+       "0   0.568308  0.373858  0.238336  0.336907  0.735189  0.208528  \n",
+       "1   0.110416  0.392077  0.189333  0.950604  0.306619  0.667940  \n",
+       "2   0.053622  0.775777  0.337353  0.908520  0.082054  0.859696  \n",
+       "3   0.652169  0.554754  0.541816  0.492460  0.231477  0.597966  \n",
+       "4   0.691991  0.576968  0.801276  0.129568  0.670519  0.744683  \n",
+       "..       ...       ...       ...       ...       ...       ...  \n",
+       "95  0.087533  0.651908  0.911708  0.725931  0.811368  0.051370  \n",
+       "96  0.477017  0.122964  0.743014  0.056588  0.223094  0.356025  \n",
+       "97  0.368581  0.667281  0.577572  0.915061  0.072751  0.537982  \n",
+       "98  0.647653  0.793831  0.414686  0.844797  0.058041  0.288947  \n",
+       "99  0.791210  0.927126  0.218500  0.859196  0.628123  0.843056  \n",
+       "\n",
+       "[100 rows x 50 columns]"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# random matrix of size 100 x 50 (n_queries, n_outputs) - i.e., 50 different values to predict\n",
+    "sample_y = pd.DataFrame(np.random.random(size=(100, 50)))\n",
+    "sample_y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "77e57e4e-6885-492a-8d21-b6b24bc6e0a9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>#sk-container-id-5 {color: black;}#sk-container-id-5 pre{padding: 0;}#sk-container-id-5 div.sk-toggleable {background-color: white;}#sk-container-id-5 label.sk-toggleable__label {cursor: pointer;display: block;width: 100%;margin-bottom: 0;padding: 0.3em;box-sizing: border-box;text-align: center;}#sk-container-id-5 label.sk-toggleable__label-arrow:before {content: \"▸\";float: left;margin-right: 0.25em;color: #696969;}#sk-container-id-5 label.sk-toggleable__label-arrow:hover:before {color: black;}#sk-container-id-5 div.sk-estimator:hover label.sk-toggleable__label-arrow:before {color: black;}#sk-container-id-5 div.sk-toggleable__content {max-height: 0;max-width: 0;overflow: hidden;text-align: left;background-color: #f0f8ff;}#sk-container-id-5 div.sk-toggleable__content pre {margin: 0.2em;color: black;border-radius: 0.25em;background-color: #f0f8ff;}#sk-container-id-5 input.sk-toggleable__control:checked~div.sk-toggleable__content {max-height: 200px;max-width: 100%;overflow: auto;}#sk-container-id-5 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {content: \"▾\";}#sk-container-id-5 div.sk-estimator input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-5 div.sk-label input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-5 input.sk-hidden--visually {border: 0;clip: rect(1px 1px 1px 1px);clip: rect(1px, 1px, 1px, 1px);height: 1px;margin: -1px;overflow: hidden;padding: 0;position: absolute;width: 1px;}#sk-container-id-5 div.sk-estimator {font-family: monospace;background-color: #f0f8ff;border: 1px dotted black;border-radius: 0.25em;box-sizing: border-box;margin-bottom: 0.5em;}#sk-container-id-5 div.sk-estimator:hover {background-color: #d4ebff;}#sk-container-id-5 div.sk-parallel-item::after {content: \"\";width: 100%;border-bottom: 1px solid gray;flex-grow: 1;}#sk-container-id-5 div.sk-label:hover label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-5 div.sk-serial::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: 0;}#sk-container-id-5 div.sk-serial {display: flex;flex-direction: column;align-items: center;background-color: white;padding-right: 0.2em;padding-left: 0.2em;position: relative;}#sk-container-id-5 div.sk-item {position: relative;z-index: 1;}#sk-container-id-5 div.sk-parallel {display: flex;align-items: stretch;justify-content: center;background-color: white;position: relative;}#sk-container-id-5 div.sk-item::before, #sk-container-id-5 div.sk-parallel-item::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: -1;}#sk-container-id-5 div.sk-parallel-item {display: flex;flex-direction: column;z-index: 1;position: relative;background-color: white;}#sk-container-id-5 div.sk-parallel-item:first-child::after {align-self: flex-end;width: 50%;}#sk-container-id-5 div.sk-parallel-item:last-child::after {align-self: flex-start;width: 50%;}#sk-container-id-5 div.sk-parallel-item:only-child::after {width: 0;}#sk-container-id-5 div.sk-dashed-wrapped {border: 1px dashed gray;margin: 0 0.4em 0.5em 0.4em;box-sizing: border-box;padding-bottom: 0.4em;background-color: white;}#sk-container-id-5 div.sk-label label {font-family: monospace;font-weight: bold;display: inline-block;line-height: 1.2em;}#sk-container-id-5 div.sk-label-container {text-align: center;}#sk-container-id-5 div.sk-container {/* jupyter's `normalize.less` sets `[hidden] { display: none; }` but bootstrap.min.css set `[hidden] { display: none !important; }` so we also need the `!important` here to be able to override the default hidden behavior on the sphinx rendered scikit-learn.org. See: https://github.com/scikit-learn/scikit-learn/issues/21755 */display: inline-block !important;position: relative;}#sk-container-id-5 div.sk-text-repr-fallback {display: none;}</style><div id=\"sk-container-id-5\" class=\"sk-top-container\"><div class=\"sk-text-repr-fallback\"><pre>GenRAPredValue(algorithm=&#x27;brute&#x27;, metric=&#x27;jaccard&#x27;, n_neighbors=8)</pre><b>In a Jupyter environment, please rerun this cell to show the HTML representation or trust the notebook. <br />On GitHub, the HTML representation is unable to render, please try loading this page with nbviewer.org.</b></div><div class=\"sk-container\" hidden><div class=\"sk-item\"><div class=\"sk-estimator sk-toggleable\"><input class=\"sk-toggleable__control sk-hidden--visually\" id=\"sk-estimator-id-5\" type=\"checkbox\" checked><label for=\"sk-estimator-id-5\" class=\"sk-toggleable__label sk-toggleable__label-arrow\">GenRAPredValue</label><div class=\"sk-toggleable__content\"><pre>GenRAPredValue(algorithm=&#x27;brute&#x27;, metric=&#x27;jaccard&#x27;, n_neighbors=8)</pre></div></div></div></div></div>"
+      ],
+      "text/plain": [
+       "GenRAPredValue(algorithm='brute', metric='jaccard', n_neighbors=8)"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "params = {\n",
+    "    \"algorithm\": \"brute\",\n",
+    "    \"metric\": \"jaccard\",\n",
+    "    \"weights\": lambda distances: 1 - distances,\n",
+    "    \"n_neighbors\": 8, # it doesn't really matter, so long as less than n_outputs\n",
+    "}\n",
+    "\n",
+    "scikit_model = KNeighborsRegressor(**params)\n",
+    "scikit_model.fit(sample_X, sample_y)\n",
+    "\n",
+    "genra_model = GenRAPredValue(**params)\n",
+    "genra_model.fit(sample_X, sample_y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "f0c13810-a6b6-412b-89ee-24983dc6a06c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "      <th>1</th>\n",
+       "      <th>2</th>\n",
+       "      <th>3</th>\n",
+       "      <th>4</th>\n",
+       "      <th>5</th>\n",
+       "      <th>6</th>\n",
+       "      <th>7</th>\n",
+       "      <th>8</th>\n",
+       "      <th>9</th>\n",
+       "      <th>...</th>\n",
+       "      <th>990</th>\n",
+       "      <th>991</th>\n",
+       "      <th>992</th>\n",
+       "      <th>993</th>\n",
+       "      <th>994</th>\n",
+       "      <th>995</th>\n",
+       "      <th>996</th>\n",
+       "      <th>997</th>\n",
+       "      <th>998</th>\n",
+       "      <th>999</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>1 rows × 1000 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   0    1    2    3    4    5    6    7    8    9    ...  990  991  992  993  \\\n",
+       "0    1    0    0    1    0    1    0    1    1    0  ...    1    1    1    1   \n",
+       "\n",
+       "   994  995  996  997  998  999  \n",
+       "0    1    1    1    1    0    1  \n",
+       "\n",
+       "[1 rows x 1000 columns]"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query_X = pd.DataFrame(np.random.randint(0,2, size=(1, 1000)))\n",
+    "query_X"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "0977b06c-f20b-40d3-8978-f96618ec2f9c",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "1211-170013:db_connection.py:80 mongodb://user:pword@ccte-mongodb-dev.epa.gov:27017/genra?serverSelectionTimeoutMS=5000&authSource=admin\n",
-      "1211-170013:db_connection.py:226 Connect '' OK: URI connector\n",
-      "1211-170013:db_connection.py:80 mongodb://user:pword@ccte-mongodb-dev.epa.gov:27017/genra?serverSelectionTimeoutMS=5000&authSource=admin\n",
-      "1211-170014:genra_celery.py:31 Using Celery broker: redis://redis:6379/0\n"
+      "/usr/local/lib/python3.11/site-packages/sklearn/metrics/pairwise.py:2182: DataConversionWarning: Data was converted to boolean for metric jaccard\n",
+      "  warnings.warn(msg, DataConversionWarning)\n"
      ]
-    }
-   ],
-   "source": [
-    "def warn(*args, **kwargs):\n",
-    "    pass\n",
-    "import warnings\n",
-    "warnings.warn = warn\n",
-    "from IPython.core.debugger import set_trace\n",
-    "import json\n",
-    "from genraweb.resources import DB\n",
-    "from genraweb.lib.fp.genfputils import FPGen\n",
-    "import pandas as pd\n",
-    "from genraweb.lib.chem_id import ChemID\n",
-    "from genra.rax.skl.cls import GenRAPredClass\n",
-    "from genra.rax.skl.reg import GenRAPredValue\n",
-    "from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor\n",
-    "\n",
-    "from genra.rax.skl.reg import GenRAPredValue\n",
-    "from sklearn.metrics import make_scorer,explained_variance_score,roc_auc_score,r2_score,f1_score,accuracy_score,precision_score,recall_score\n",
-    "from sklearn.model_selection import GridSearchCV\n",
-    "from sklearn.model_selection import LeaveOneOut\n",
-    "import time\n",
-    "import seaborn as sns\n",
-    "import pylab as pl\n",
-    "import os\n",
-    "\n",
-    "import itertools\n",
-    "\n",
-    "\n",
-    "from genraweb.lib.new_genrapy import GenRAPredClassHybrid, GenRAPredValueHybrid, GenRAPredBinaryHybrid\n",
-    "import numpy as np"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "d186373d-d22f-43e0-939c-220141c7ae2e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data = pd.read_csv(\"/genra/gridsearch_data.csv\").set_index(\"dsstox_sid\")\n",
-    "with open(\"/genra/gridsearch_slices.json\", \"r\") as f:\n",
-    "    slices = json.load(f)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "418e54fb-de51-4860-b9f4-9fc67a95f404",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(432, 5740)\n",
-      "(415, 5740)\n",
-      "(432,)\n",
-      "(415,)\n"
-     ]
-    }
-   ],
-   "source": [
-    "y = 'CHR:liver__tox_txrf_binary'\n",
-    "df = data[data[y].notnull()]\n",
-    "fp_slices = [slice(elem[\"start\"],elem[\"end\"]) for elem in slices[:5]]\n",
-    "cols_list = list(df.columns)\n",
-    "cols = []\n",
-    "[cols.extend(cols_list[_slice]) for _slice in fp_slices]\n",
-    "\n",
-    "X_sample = df[cols]\n",
-    "is_na = X_sample.isna().sum(axis=1)\n",
-    "print(X_sample.shape)\n",
-    "X_sample = X_sample.drop(is_na[is_na>0].index)\n",
-    "print(X_sample.shape)\n",
-    "Y_sample = df[y]\n",
-    "print(Y_sample.shape)\n",
-    "Y_sample = Y_sample.reindex(index=X_sample.index)\n",
-    "print(Y_sample.shape)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "id": "550d8c52-00a4-4309-9513-5aafe97335c0",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting 5 folds for each of 152 candidates, totalling 760 fits\n",
-      "12.75064754486084\n"
-     ]
-    }
-   ],
-   "source": [
-    "hybrid_binary = GenRAPredBinaryHybrid(\n",
-    "    algorithm='brute',\n",
-    "    metric='jaccard',\n",
-    ")\n",
-    "params = [\n",
-    "    {\n",
-    "        \"n_neighbors\": range(1, 20),\n",
-    "        \"metric\": [\"euclidean\", \"jaccard\"],\n",
-    "        \"hybrid_weights\": [\n",
-    "            (1, 0, 0, 0, 0),\n",
-    "            (1, 1, 1, 1, 1),\n",
-    "            (3, 1, 1, 1, 1),\n",
-    "        ],\n",
-    "        \"slices\": [fp_slices]\n",
-    "    },\n",
-    "    {\n",
-    "        \"n_neighbors\": range(1, 20),\n",
-    "        \"metric\": [\"euclidean\", \"jaccard\"],\n",
-    "        \"hybrid_weights\": [(1,)],\n",
-    "        \"slices\": [[slice(0,None)]]\n",
-    "    }\n",
-    "]\n",
-    "grid = GridSearchCV(\n",
-    "    estimator=hybrid_binary,\n",
-    "    param_grid=params,\n",
-    "    n_jobs=30,\n",
-    "    cv=5,\n",
-    "    verbose=1,\n",
-    "    scoring=make_scorer(f1_score),\n",
-    ")\n",
-    "os.environ['PYTHONWARNINGS']='ignore'\n",
-    "start_time = time.time()\n",
-    "best = grid.fit(X_sample, Y_sample)\n",
-    "run_time_binary = time.time() - start_time\n",
-    "print(run_time_binary)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "id": "94643969-d78f-45bd-ab87-c366fdece7d0",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.870748299319728"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "best.best_score_"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "id": "08b7fee3-b4b4-4782-883f-1d3df5860a40",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'hybrid_weights': (1, 0, 0, 0, 0),\n",
-       " 'metric': 'jaccard',\n",
-       " 'n_neighbors': 19,\n",
-       " 'slices': [slice(0, 2048, None),\n",
-       "  slice(2048, 3678, None),\n",
-       "  slice(3678, 4227, None),\n",
-       "  slice(4227, 4806, None),\n",
-       "  slice(4806, 5740, None)]}"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "best.best_params_"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "id": "e270b641-6f85-4032-8a31-1a44f89798f4",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.plotly.v1+json": {
-       "config": {
-        "plotlyServerURL": "https://plot.ly"
-       },
-       "data": [
-        {
-         "hovertemplate": "param_hybrid_weights=(1, 0, 0, 0, 0)<br>param_n_neighbors=%{x}<br>mean_test_score=%{y}<extra></extra>",
-         "legendgroup": "(1, 0, 0, 0, 0)",
-         "line": {
-          "color": "#636efa",
-          "dash": "solid"
-         },
-         "marker": {
-          "symbol": "circle"
-         },
-         "mode": "lines",
-         "name": "(1, 0, 0, 0, 0)",
-         "orientation": "v",
-         "showlegend": true,
-         "type": "scatter",
-         "x": [
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10,
-          11,
-          12,
-          13,
-          14,
-          15,
-          16,
-          17,
-          18,
-          19
-         ],
-         "xaxis": "x",
-         "y": [
-          0.8008378078301959,
-          0.8400062445502972,
-          0.8096721096361099,
-          0.8559125351204843,
-          0.8336324358130058,
-          0.8527611277611278,
-          0.8366577903898239,
-          0.8614862699888679,
-          0.8543397891689771,
-          0.8646500028077732,
-          0.8579139153827342,
-          0.8649543378995436,
-          0.8570850413953863,
-          0.8684907085177009,
-          0.8638235448485803,
-          0.870748299319728
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hovertemplate": "param_hybrid_weights=(1, 1, 1, 1, 1)<br>param_n_neighbors=%{x}<br>mean_test_score=%{y}<extra></extra>",
-         "legendgroup": "(1, 1, 1, 1, 1)",
-         "line": {
-          "color": "#EF553B",
-          "dash": "solid"
-         },
-         "marker": {
-          "symbol": "circle"
-         },
-         "mode": "lines",
-         "name": "(1, 1, 1, 1, 1)",
-         "orientation": "v",
-         "showlegend": true,
-         "type": "scatter",
-         "x": [
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10,
-          11,
-          12,
-          13,
-          14,
-          15,
-          16,
-          17,
-          18,
-          19
-         ],
-         "xaxis": "x",
-         "y": [
-          0.8075935453622654,
-          0.8430578785922963,
-          0.8186283695823878,
-          0.8460811690308093,
-          0.8401247232523816,
-          0.8613621686330353,
-          0.8420278333481293,
-          0.860641288478862,
-          0.8498768836797005,
-          0.8614241048332417,
-          0.8543264207057311,
-          0.867633122214403,
-          0.8680721392635153,
-          0.8692013791818098,
-          0.8692013791818098,
-          0.8692013791818098
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hovertemplate": "param_hybrid_weights=(3, 1, 1, 1, 1)<br>param_n_neighbors=%{x}<br>mean_test_score=%{y}<extra></extra>",
-         "legendgroup": "(3, 1, 1, 1, 1)",
-         "line": {
-          "color": "#00cc96",
-          "dash": "solid"
-         },
-         "marker": {
-          "symbol": "circle"
-         },
-         "mode": "lines",
-         "name": "(3, 1, 1, 1, 1)",
-         "orientation": "v",
-         "showlegend": true,
-         "type": "scatter",
-         "x": [
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10,
-          11,
-          12,
-          13,
-          14,
-          15,
-          16,
-          17,
-          18,
-          19
-         ],
-         "xaxis": "x",
-         "y": [
-          0.8042368616580481,
-          0.8524093598806555,
-          0.8216261310206399,
-          0.848984918136226,
-          0.8427930652715798,
-          0.8622252963759347,
-          0.854621049850091,
-          0.8638022080190918,
-          0.8519063391000493,
-          0.86297102497116,
-          0.8578221153148611,
-          0.8657296456608151,
-          0.8653682852451325,
-          0.867633122214403,
-          0.8688259281038822,
-          0.8692013791818098
-         ],
-         "yaxis": "y"
-        },
-        {
-         "hovertemplate": "param_hybrid_weights=(1,)<br>param_n_neighbors=%{x}<br>mean_test_score=%{y}<extra></extra>",
-         "legendgroup": "(1,)",
-         "line": {
-          "color": "#ab63fa",
-          "dash": "solid"
-         },
-         "marker": {
-          "symbol": "circle"
-         },
-         "mode": "lines",
-         "name": "(1,)",
-         "orientation": "v",
-         "showlegend": true,
-         "type": "scatter",
-         "x": [
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10,
-          11,
-          12,
-          13,
-          14,
-          15,
-          16,
-          17,
-          18,
-          19
-         ],
-         "xaxis": "x",
-         "y": [
-          0.7546531749844266,
-          0.8236489483815183,
-          0.7971094199066515,
-          0.8240579332078364,
-          0.802456834960865,
-          0.8394657957400525,
-          0.8231423720288751,
-          0.8521637096606087,
-          0.8431410284217963,
-          0.861854780372371,
-          0.8534741237538748,
-          0.860362294426858,
-          0.8563573621610562,
-          0.8654881749426915,
-          0.8587845852444392,
-          0.8677751535191309
-         ],
-         "yaxis": "y"
-        }
-       ],
-       "layout": {
-        "autosize": true,
-        "legend": {
-         "title": {
-          "text": "param_hybrid_weights"
-         },
-         "tracegroupgap": 0
-        },
-        "margin": {
-         "t": 60
-        },
-        "template": {
-         "data": {
-          "bar": [
-           {
-            "error_x": {
-             "color": "#2a3f5f"
-            },
-            "error_y": {
-             "color": "#2a3f5f"
-            },
-            "marker": {
-             "line": {
-              "color": "#E5ECF6",
-              "width": 0.5
-             },
-             "pattern": {
-              "fillmode": "overlay",
-              "size": 10,
-              "solidity": 0.2
-             }
-            },
-            "type": "bar"
-           }
-          ],
-          "barpolar": [
-           {
-            "marker": {
-             "line": {
-              "color": "#E5ECF6",
-              "width": 0.5
-             },
-             "pattern": {
-              "fillmode": "overlay",
-              "size": 10,
-              "solidity": 0.2
-             }
-            },
-            "type": "barpolar"
-           }
-          ],
-          "carpet": [
-           {
-            "aaxis": {
-             "endlinecolor": "#2a3f5f",
-             "gridcolor": "white",
-             "linecolor": "white",
-             "minorgridcolor": "white",
-             "startlinecolor": "#2a3f5f"
-            },
-            "baxis": {
-             "endlinecolor": "#2a3f5f",
-             "gridcolor": "white",
-             "linecolor": "white",
-             "minorgridcolor": "white",
-             "startlinecolor": "#2a3f5f"
-            },
-            "type": "carpet"
-           }
-          ],
-          "choropleth": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "type": "choropleth"
-           }
-          ],
-          "contour": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1,
-              "#f0f921"
-             ]
-            ],
-            "type": "contour"
-           }
-          ],
-          "contourcarpet": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "type": "contourcarpet"
-           }
-          ],
-          "heatmap": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1,
-              "#f0f921"
-             ]
-            ],
-            "type": "heatmap"
-           }
-          ],
-          "heatmapgl": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1,
-              "#f0f921"
-             ]
-            ],
-            "type": "heatmapgl"
-           }
-          ],
-          "histogram": [
-           {
-            "marker": {
-             "pattern": {
-              "fillmode": "overlay",
-              "size": 10,
-              "solidity": 0.2
-             }
-            },
-            "type": "histogram"
-           }
-          ],
-          "histogram2d": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1,
-              "#f0f921"
-             ]
-            ],
-            "type": "histogram2d"
-           }
-          ],
-          "histogram2dcontour": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1,
-              "#f0f921"
-             ]
-            ],
-            "type": "histogram2dcontour"
-           }
-          ],
-          "mesh3d": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "type": "mesh3d"
-           }
-          ],
-          "parcoords": [
-           {
-            "line": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "parcoords"
-           }
-          ],
-          "pie": [
-           {
-            "automargin": true,
-            "type": "pie"
-           }
-          ],
-          "scatter": [
-           {
-            "fillpattern": {
-             "fillmode": "overlay",
-             "size": 10,
-             "solidity": 0.2
-            },
-            "type": "scatter"
-           }
-          ],
-          "scatter3d": [
-           {
-            "line": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatter3d"
-           }
-          ],
-          "scattercarpet": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattercarpet"
-           }
-          ],
-          "scattergeo": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattergeo"
-           }
-          ],
-          "scattergl": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattergl"
-           }
-          ],
-          "scattermapbox": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scattermapbox"
-           }
-          ],
-          "scatterpolar": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatterpolar"
-           }
-          ],
-          "scatterpolargl": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatterpolargl"
-           }
-          ],
-          "scatterternary": [
-           {
-            "marker": {
-             "colorbar": {
-              "outlinewidth": 0,
-              "ticks": ""
-             }
-            },
-            "type": "scatterternary"
-           }
-          ],
-          "surface": [
-           {
-            "colorbar": {
-             "outlinewidth": 0,
-             "ticks": ""
-            },
-            "colorscale": [
-             [
-              0,
-              "#0d0887"
-             ],
-             [
-              0.1111111111111111,
-              "#46039f"
-             ],
-             [
-              0.2222222222222222,
-              "#7201a8"
-             ],
-             [
-              0.3333333333333333,
-              "#9c179e"
-             ],
-             [
-              0.4444444444444444,
-              "#bd3786"
-             ],
-             [
-              0.5555555555555556,
-              "#d8576b"
-             ],
-             [
-              0.6666666666666666,
-              "#ed7953"
-             ],
-             [
-              0.7777777777777778,
-              "#fb9f3a"
-             ],
-             [
-              0.8888888888888888,
-              "#fdca26"
-             ],
-             [
-              1,
-              "#f0f921"
-             ]
-            ],
-            "type": "surface"
-           }
-          ],
-          "table": [
-           {
-            "cells": {
-             "fill": {
-              "color": "#EBF0F8"
-             },
-             "line": {
-              "color": "white"
-             }
-            },
-            "header": {
-             "fill": {
-              "color": "#C8D4E3"
-             },
-             "line": {
-              "color": "white"
-             }
-            },
-            "type": "table"
-           }
-          ]
-         },
-         "layout": {
-          "annotationdefaults": {
-           "arrowcolor": "#2a3f5f",
-           "arrowhead": 0,
-           "arrowwidth": 1
-          },
-          "autotypenumbers": "strict",
-          "coloraxis": {
-           "colorbar": {
-            "outlinewidth": 0,
-            "ticks": ""
-           }
-          },
-          "colorscale": {
-           "diverging": [
-            [
-             0,
-             "#8e0152"
-            ],
-            [
-             0.1,
-             "#c51b7d"
-            ],
-            [
-             0.2,
-             "#de77ae"
-            ],
-            [
-             0.3,
-             "#f1b6da"
-            ],
-            [
-             0.4,
-             "#fde0ef"
-            ],
-            [
-             0.5,
-             "#f7f7f7"
-            ],
-            [
-             0.6,
-             "#e6f5d0"
-            ],
-            [
-             0.7,
-             "#b8e186"
-            ],
-            [
-             0.8,
-             "#7fbc41"
-            ],
-            [
-             0.9,
-             "#4d9221"
-            ],
-            [
-             1,
-             "#276419"
-            ]
-           ],
-           "sequential": [
-            [
-             0,
-             "#0d0887"
-            ],
-            [
-             0.1111111111111111,
-             "#46039f"
-            ],
-            [
-             0.2222222222222222,
-             "#7201a8"
-            ],
-            [
-             0.3333333333333333,
-             "#9c179e"
-            ],
-            [
-             0.4444444444444444,
-             "#bd3786"
-            ],
-            [
-             0.5555555555555556,
-             "#d8576b"
-            ],
-            [
-             0.6666666666666666,
-             "#ed7953"
-            ],
-            [
-             0.7777777777777778,
-             "#fb9f3a"
-            ],
-            [
-             0.8888888888888888,
-             "#fdca26"
-            ],
-            [
-             1,
-             "#f0f921"
-            ]
-           ],
-           "sequentialminus": [
-            [
-             0,
-             "#0d0887"
-            ],
-            [
-             0.1111111111111111,
-             "#46039f"
-            ],
-            [
-             0.2222222222222222,
-             "#7201a8"
-            ],
-            [
-             0.3333333333333333,
-             "#9c179e"
-            ],
-            [
-             0.4444444444444444,
-             "#bd3786"
-            ],
-            [
-             0.5555555555555556,
-             "#d8576b"
-            ],
-            [
-             0.6666666666666666,
-             "#ed7953"
-            ],
-            [
-             0.7777777777777778,
-             "#fb9f3a"
-            ],
-            [
-             0.8888888888888888,
-             "#fdca26"
-            ],
-            [
-             1,
-             "#f0f921"
-            ]
-           ]
-          },
-          "colorway": [
-           "#636efa",
-           "#EF553B",
-           "#00cc96",
-           "#ab63fa",
-           "#FFA15A",
-           "#19d3f3",
-           "#FF6692",
-           "#B6E880",
-           "#FF97FF",
-           "#FECB52"
-          ],
-          "font": {
-           "color": "#2a3f5f"
-          },
-          "geo": {
-           "bgcolor": "white",
-           "lakecolor": "white",
-           "landcolor": "#E5ECF6",
-           "showlakes": true,
-           "showland": true,
-           "subunitcolor": "white"
-          },
-          "hoverlabel": {
-           "align": "left"
-          },
-          "hovermode": "closest",
-          "mapbox": {
-           "style": "light"
-          },
-          "paper_bgcolor": "white",
-          "plot_bgcolor": "#E5ECF6",
-          "polar": {
-           "angularaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           },
-           "bgcolor": "#E5ECF6",
-           "radialaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           }
-          },
-          "scene": {
-           "xaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "gridwidth": 2,
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white"
-           },
-           "yaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "gridwidth": 2,
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white"
-           },
-           "zaxis": {
-            "backgroundcolor": "#E5ECF6",
-            "gridcolor": "white",
-            "gridwidth": 2,
-            "linecolor": "white",
-            "showbackground": true,
-            "ticks": "",
-            "zerolinecolor": "white"
-           }
-          },
-          "shapedefaults": {
-           "line": {
-            "color": "#2a3f5f"
-           }
-          },
-          "ternary": {
-           "aaxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           },
-           "baxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           },
-           "bgcolor": "#E5ECF6",
-           "caxis": {
-            "gridcolor": "white",
-            "linecolor": "white",
-            "ticks": ""
-           }
-          },
-          "title": {
-           "x": 0.05
-          },
-          "xaxis": {
-           "automargin": true,
-           "gridcolor": "white",
-           "linecolor": "white",
-           "ticks": "",
-           "title": {
-            "standoff": 15
-           },
-           "zerolinecolor": "white",
-           "zerolinewidth": 2
-          },
-          "yaxis": {
-           "automargin": true,
-           "gridcolor": "white",
-           "linecolor": "white",
-           "ticks": "",
-           "title": {
-            "standoff": 15
-           },
-           "zerolinecolor": "white",
-           "zerolinewidth": 2
-          }
-         }
-        },
-        "xaxis": {
-         "anchor": "y",
-         "autorange": true,
-         "domain": [
-          0,
-          1
-         ],
-         "range": [
-          4,
-          19
-         ],
-         "title": {
-          "text": "param_n_neighbors"
-         },
-         "type": "linear"
-        },
-        "yaxis": {
-         "anchor": "x",
-         "autorange": true,
-         "domain": [
-          0,
-          1
-         ],
-         "range": [
-          0.7482034458546877,
-          0.8771980284494669
-         ],
-         "title": {
-          "text": "mean_test_score"
-         },
-         "type": "linear"
-        }
-       }
-      },
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlUAAAFoCAYAAAB+Cg5cAAAAAXNSR0IArs4c6QAAIABJREFUeF7snQd4FFXXx/8zsyUd0gOh94ACgkiRJkVAQBQFRdRXUQQLIhYU9PUVGyhYQAQVaVJEuoIU6SAd6b1DSAjpPVtnvu/Osslm2WTbbCDx3OfhCdm9bX73Lvvn3HPP4SRJkkCFCBABIkAEiAARIAJEwCsCHIkqr/hRYyJABIgAESACRIAIyARIVNFGIAJEgAgQASJABIiAAgRIVCkAkbogAkSACBABIkAEiACJKtoDRIAIEAEiQASIABFQgACJKgUgUhdEgAgQASJABIgAESBRRXuACBABIkAEiAARIAIKECBRpQBE6oIIEAEiQASIABEgAiSqaA8QASJABIgAESACREABAiSqFIBIXRABIkAEiAARIAJEgEQV7QEiQASIABEgAkSACChAgESVAhCpCyJABIgAESACRIAIkKiiPUAEiAARIAJEgAgQAQUIkKhSACJ1QQSIABEgAkSACBABElW0B4gAESACRIAIEAEioAABElUKQKQuiAARIAJEgAgQASJAoor2ABEgAkSACBABIkAEFCBAokoBiNQFESACRIAIEAEiQARIVNEeIAJEgAgQASJABIiAAgRIVCkAkbogAkSACBABIkAEiACJKtoDRIAIEAEiQASIABFQgACJKgUgUhdEgAgQASJABIgAESBRRXuACBABIkAEiAARIAIKECBRpQBE6oIIEAEiQASIABEgAiSqaA8QASJABIgAESACREABAiSqFIBIXRABIkAEiAARIAJEgEQV7QEiQASIABEgAkSACChAgESVAhCpCyJABIgAESACRIAIkKiiPUAEiAARIAJEgAgQAQUIkKhSACJ1QQSIABEgAkSACBABElW0B4gAESACRIAIEAEioAABElUKQKQuiAARIAJEgAgQASJAoor2ABEgAkSACBABIkAEFCBAokoBiNQFESACRIAIEAEiQARIVNEeIAJEgAgQASJABIiAAgRIVCkAkbogAkSACBABIkAEiACJKtoDRIAIEAEiQASIABFQgACJKgUgUhdEgAgQASJABIgAESBRRXuACBABIkAEiAARIAIKECBRpQBE6oIIEAEiQASIABEgAiSqaA8QASJABIgAESACREABAiSqFIBIXRABIkAEiAARIAJEgEQV7QEiQASIABEgAkSACChAgESVAhCpCyJABIgAESACRIAIkKiiPUAEiAARIAJEgAgQAQUIkKhSACJ1QQSIABEgAkSACBABElW0B4gAESACRIAIEAEioAABElUKQKQuiAARIAJEgAgQASJAoor2ABEgAkSACBABIkAEFCBAokoBiNQFESACRIAIEAEiQARIVNEeIAJEgAgQASJABIiAAgRIVCkAkbogAkSACBABIkAEiACJKtoDRIAIEAEiQASIABFQgACJKgUgUhdEgAgQASJABIgAESBRRXuACBABIkAEiAARIAIKECBRpQBE6oIIEAEiQASIABEgAiSqaA8QASJABIgAESACREABAiSqFIBIXRABIkAEiAARIAJEgEQV7QEiQASIABEgAkSACChAgESVAhCpCyJABIgAESACRIAIkKjycg8kphV42cOtzQO0AjRqAZm5BsX7pg59SyAsWIN8nQk6o+jbgah3xQlUDfeHLz7Pik+0HHfIGFMhAhWZAIkqL1fXF/8Ik6jyclFuY3MSVbcRvpdDk6jyEqALzUlUuQCJqpRrAiSqvFw+ElVeAqxgzUlUld8FJVHl+7UjUeV7xjTC7SVAospL/iSqvARYwZqTqCq/C0qiyvdrR6LK94xphNtLgESVl/xJVHkJsII1J1FVfheURJXv145Ele8Z0wi3lwCJKi/5k6jyEmAFa06iqvwuKIkq368diSrfM6YRbi8BElVe8idR5SXACtacRFX5XVASVb5fOxJVvmdMI9xeAiSqvORPospLgBWsOYmq8rugJKp8v3b/ZlG1//BpfPXjYkyfMAqhlYI9gq1EHyUNXKAz4H8TZ6FNy8bo/1BHj+ZX1o3uxDmTqPJyF5Co8hJgBWtOoqr8LiiJKt+vHYmq2yeqlq/ZjsWrtpYo6u4EgcJE45jxM/Djl2+hbs2qTjekK3POyMrBy+99g7eGDUSr5o2c9ultBRJVXhIkUeUlwArWnERV+V1QElW+XzsSVbdPVDlbXVcEirM+yvp9V+ZMoqqsV8XL8UhUeQmwgjUnUVV+F5RElW/WzmwG9u3ncekK8PYrWqeDWL8EX/lPP6zesBt/btojt/lk9JDCY6kLVxIxbPRXuH4jrbA/2/cd9dG7axu88dIAvPnR9zh26mJhuxcGPYQ3hw2Uf7d+STdtXBdHT14oHJvVef7JXrLFw9rWdjynDwXAenTHLCbMGmOd+5xv35MtKCV9+dse+Z2/lCAfIT7/RE+8+dE0edgq0eHFLDvMIrXnn5Po072tPF9W2Bjxicny6+PeGQJ/P438Oqv73y9nFZu+q89lZRUTFVbIz/540tEz2Y9pfX42CUfHm47Wmq0lew5WrEeWl+OTMPPXNfJr9u9b9xB77+64OrK1zk+rldvavufqs5e23mSpcuXTUEodElVeAqxgzUlUld8FJVGl7NpJEnDsOI+NWzhkZnJy5z9PVjsdxPpFnJqeVSgWrF+s48cMlQUI+33Tjn/w0tN95f7s33fUB6vHXp+9aC1e/s8jsrCw1hvYt7Ms2KxC4eDxc7eMzdpbj6XYeO+Pn4HPxgx16ZjKKhiee2NC4Rc+G9/+SO7rHxcjKTm9UPjYCxcmOlgftkLQvg+raLGtYxVQtqLKvp0rVh/7xbMKOKtQY/NnwsYqlBinidMWYfzYobIfmX19+3WzF1X279s/h1VUMWFkL06ta1qSWGVzZcUqqO33htONWkIFElWekrvZjkSVlwArWHMSVeV3QcuLqOJys8DlZAH52eCYGegOKAUQYeQkGGH5c/WGhEMngPRcwCxIgFpCzdpmvP1MV6ezdfVL0L4j9iVZq3qMLI7cOfJhX/TMysG+XB0JC1dfc/ZgJVlhbMWZvViz/91RH/bPai9crPOyfV2n19/iZ+SJqLKdDxtn/JQFqFc7Frl5BTJP+zHHfD4D77zyZDEhaitu7J/PXviUJKrsnett2znaC548q7P1tb5PospVUiXUI1HlJcAK1pxEVfld0NshqriCfHB5WWBCCfm54LIywOVlQropnPi8bHC52UBuplyHy8tRBHByoB+SA/2R5q9FUlAAUgK1uBHoj5QALdh7eWo1jAIHoyDAcPOnkedh4HkYBR4GgUeexrnVyX6yUsuXnc6/JEFkLxasVhvbDq3WmdJElavHSdYbcGUpquwtU/aWK0eiyn5+roiqxBupt1jaPBEatpzZOuzYexT9erYvtE4xq6BV6Dribl0767rZPp/1eM5eMNk+n9VS5a6osooz69Gn9bjQeizqdJOWUoFElTf0AJ9ktaeEyl4uym1sTqLqNsL3cmhnoooz6gGDEfJPkwGcwQDJpAeMhlItRlxaMvgrp4EcJooyweVkA3nZ4LOK/IHcmbrkHwi9phKu54eCVwkICASCAoG0SmqkaAWka9RI8lchWcv+CEjxUyNVo0Kyn+VPmlblznAu1dWaRajMkvxHLUpQs5+SBD9I0EgSNKIEP7OEnT3fdtqfK6Jq+tyVWLN5bzFfImfWCdsvUls/Hmdf0mUpqqxzZLf0Ph8zFGPHzyh2a01JUWV7LMfG9URU2bZh1r4OrZvirkZ1MHH6IvR/qAN+WbweA/p2LjyydXZk6khUWds7srh5I6ps+1NSXJGocvoRL70CWaq8BFjBmpOoKp8LKpw7ioA1c2HMyweMenBGIyT5pwFcQZ7PHkpSayAFVQICQyAFV5L/LgVWAkIqQwoMAW6+hoBKkIJDcNQPWHEiEzsTM5AeloY8/3wU+BdAr9W7NcfKvAaRgh8ihABE8v6IEPwQrQpAhOCPGFUA/DkBGvBQcwLU7CfPyX8v9hrHQSxQY9sODrv38oXj168nokc3CVFRUuFrulQOacd4tHrc4iBdWnF2/Mf8oZiDsf2XrSuiyvaI0NUv6bIWVdbnZw7xVqdqa1wrpY7/lLJUWUUg89XKzs0vPNpjnHPzdUhMSi30p3LlSNYXlirr+tnvF/s9qFQMMBJVzj7hTt4nUeUlwArWnERV+VtQ4eJJaCa/C86gczp5SesPMCGk0co/oSr6u6TSAPLrakCtlf8uqdSAxg8IDIYUVBlSMBNLQbJwksKjSxzvujkPZ4yZOK5Px0l9Os4aM3HKmFHq/Pz0fvDP94O/zh9hnD9qhfijYZQfYv39EcMHIEzQIpKJJiHA6XM6q2A0Abv2CPj7b0BvsDihx8ZK6PWgiBrVi8QUez1pF4/La3iIRuDxn50fGTr68rWNX1Q1OkIWVfa3zmwduEsTZraO4NYjqRZ31b/lNtntOP6zcrc6fNvfRnP0xW9/ROjK8R875rL3V7I6uLt7A856DGt7hOboNfZsbEx7CyOry24mMt72z2fvTG9d1xpVo0pcL+s47Ketn5ztfmH9MP+vMa8PLgzEWhI3Z58F+/dJVLlLzK4+iSovAVaw5iSqyteCCpdPQ/PtaHD6Aqhbd0Jux8duCiY1pJvCiIkkSeu9ECmJzBFDKk4aMnBGn4HjxnQc16ciRzI5rB6cE4zI7DB0qRmKdmFhiFUFyRanKD4AV67wOHQEOHGKg+Gm0OE4oE5tEU3vBhrHSdBqigsed1dLFIFDh3ls2sohN9cipiIjJXTrIiGuoVisO0MWh/NLOGSes1ixotuI6PCi6yEVbMMe2IcNsLXmsL6ZT461sC/SkkSV1WphvUbPhIA1fIL9Ff3bKapKCoLpyI/M3h/IVVFlz2LMiMFyGAl3I6rb36Bk6+DoNev62IdUsF1bR6LRtj6z3HW5/x6w0BIlrZe9qGK/2/pzWa1/zN/LGoKB1bG3Crr72bDWJ1HlKbmb7UhUeQmwgjUnUVV+FpRPvATNpDfAF+TjWos2WPnsk9DrAS3Hw59TQcsJ8IMALS/Aj1PBj+OhlX+qoOV5y2sQEMw7t74wKvHmXJzSZ8gWpxP6NJwyZOCiKduxeOJUiNOE4S5NOGpJoTi3IQz8pQhEBgl4/lkRlStLYKJFU+lWkWQyASdP8zh8BLhwkQcLbcCKIAAN64to1hRoUF+Uf3ennDrNY8MmIDXNIpIqVZLQpbOE5k1FMPFmW1KPcLiwnIdZx0EVJKHBExIqNxDhSvBPV46J3Jl3eayrlNWkPD67sznb3tZ0Vvd2vE+iykvqJKq8BFjBmpOoKh8LygSV9us3weXlYnKfbpjQpAp0KG5pcfdJmBArEl6CRZRxAgSOx2lDBvJLsD7VVYWgvqYymmkj0EQThobqyqimCpKHT0nmMHcBj+wcDrFVJTw7WIS/v4Trf1uO1AKiJdTsKaGynZXIOndmTTpyjMfRo8D1G0XKh1ms4uKYILJYskor8fEc1m7gce2apX2Av4TOnSS0ue/WduYCDueWckg/bhFeYXeJqP+4BMHfouwqoqhyFEDTnqc7R2p3gqgs7aae9dmUvDFX0v6zj0d2J7Bx9u8CiSpnhJy8T6LKS4AVrDmJKsuCnjvP4+IlCZ06AH5+3h05Kb1F+KR4aCe9jv2h/hjZpwNOV/KXh6iUVQkRvD/CwwC+yO+6cHgjzNCJJujZT4n93Qy9ZCrxqM5+3iG8GnfJ1qcINNSEIo4JKU1EiY936TKPhYs42WcprpGIAf1FSAUczi7ikHW++ASDakio1UtESJ2SWScnczh4mMPhIxzyC4oEVlCQhKZ3Sbj7LkkWbtaSlsbhr40cTp2xjKVWAfe3M+P+dnB4jJh5lsfZ3ziYcjnwfhLq9pMQ2aK48KqIokrp/eksR5/S493J/TkSd7Y3N+/EuZOo8nJVSFR5CbCCNfeVqDpnzIKa41BLFXLHE9u6Q8DmLZYvbY1Gkr+E729jhsb5xS+fPxufkoC8Ke9g3L11MK9ZPcscDRq0OtgKjc7Gyb9rtRYfodat3LNcMUuURWwVCS89E14wo5YqGNFuOIgfOcpj2UqLmGHz6N1LRPoJXrYCmfNvipaHJYgm4OoGDsYcC+9K9UTU7CUhqFrpQvb8BYv/1clTPGzjh4aHSWjaFMjKlHDwcJFwY3Ng1qnAgFv7ZQ7ol1bxuHHzBmBIXVE+7nN0NOmKqPL5JqABiIAPCZCo8hIuiSovAVaw5r4QVbNyTuG/aXsRwfthcUxPNNRUviOp6fQclq/kcPqmZYPdBktIsHzZsyOrju2B+1qZZYvH7ShcWhKWrJqIj1o3QIa/xWG63sV6aL2/Dbq2VKPNPVr8ucmA06ctYiImWkK/PqJ8q60sy7YdAjbdFKU9uotoe6+Ii7/zSN5vmVdwbQmNBotQB1vmxU4Vk/bxiN9ksRKxEhonyseCATGlz93w/zfyjp+0+F9dvnyrea7p3SK6dpEQ6sB3i42Tc4XD2V956DM4cAJQq7eIKu1EwM7HysqPRFVZ7iQa63YQIFHlJXUSVV4CrGDNlRRVaaIOI5N3YIsuoZBSIKfCwioP4l5N1B1Fjjkvz1vAISOTk4+GbgzYg+N+CXicb4yAnXVx8aRFxAQGSujUUUKrFu47SnvzwOfSLuLds79jb5VQuZuwjBDcv68jesZEyaIhOFiS/X3Y5/ncBR6r/izKV9eyhSXukq+PMdnNuqUrBBw/wUHggcf7m1GrMnD6F4toARMtPUVU7eBYtDCL0fVdAhK2AqZ8i6oJv1tCzV4i/MKdC8OcHHY0yCxYEsLCgAe7Fo81VYy/Gbi8nkPidgGQgMCqEhoOFuEXUfo4JKq82cXUtjwQIFHl5SqRqPIS4G1q/mn6frxQqTGqCIGKzkApUbWlIAEjU7YjTbQEdXw/9F6cNKRhRd4l+cbZjOgH0MW/mqJz97SzM+d4LF7Kw2gEQqIMONBnE/YXJEOnNspdsvk+yNdB7OFGMBy2xGZiN8ce6CihWTNRFhC+KgWSCROv78SPhkvyEFqjGfceaYmHjS3QozsQGVF0xGcbUZ0dibGgljt2CvLxGHPOfvBBCfc4uOmmxNwNBmD+Il62FrHjx2efEsGd43F1/U1LX6SIhoMlBFRxLo7MBshiJ3EbYL4ZWiHiHhE1e0jQhjpv7+x5CpI4nF7Io+Cm43u1rmbUeNC1fklUOaNL75d3AhVSVNnHMHHm2GbvDGd/U8M+noft+ySqyt9HYGrWMYzP+Eee+Fuh9+DNSs0UewglRNX7aXswJ+e0PCfmizMjugv8E8IRGyvi4+w9mH3zve8jO+KRwDqKzd2TjjZu5rD9b8vd/Kp352Jpq/U4ZcrAy9s6oM216pj64Hbsj7xW2HUdqTIanItD5MH6si8TCw3QpZOE5s3c819yZa5/5l/G+9f3IEWwBPXsdToVTZOeQ78ukahZ41YR4ChNTUYWh1WrOTAfJFaqV5PQr6+IqEjXRIQr88zN4zB3Ho8byZxsMXu6H5D8J5B387ZdTFsRtfuI4Nw8NmU38eK3sOCbghx4k1m6oluJqNFNKjw6dGV+hXUkIHGbgMt/cYAZsvWr4SARgXbBPkvrk0SVW8SpcjkkUOFElX1KAfss3/ZrZH9F0/53Z/mQSFSVr11/1piFBxJWFJt0rCoQ48LuQ6+Aml4/jDei6rQxA8OSt+C80RK76PngRvhveCtIOhWmfZUHgyYYD3SWsKfBYXyZcVCu81l4GzwX3MjrebvbgU7HYfGyIrFRt2cKvo5Zj1RRh47XamPEqq6FXeqaZ2F+u71YL10tNkyza/VR/XhDRCfHyBajbg8AcXHei6tEUx7eSNiNnZJFzFXPysW4zZdRt9P/UK9FcImPWlruPxajac16DllZFssRCyfAjg29DaZpGzKB+XD1bSohcS0Hs56DKkBCg0GW+E7eFGMuh/iNHJJ2F5kEq9wvono3SR7DlaLL4HB2IY/cq5bn91TokahyhTbVKc8EKpyoYiLKNlGkM1FkL7ocZfxmiSJZlF5HhURV+dr+3RN+x0ljBt7beQxtriVj1BN9cAkFli9KbQwmRbZDbS9u2HkqqmbmnMSnaQdggCg7pH8f1Qnt/arI89qwmUOzla/jhroWllR6B6GVJZh6nsZkzU7mziJb2pjFrawKEwLzf+XBrDhaPwk1BlzFOH4L2FFbS2ME3p/5AMxSJQSZLyBXqCtPS+OnQ9hACcuqHsOi3PNIMucXTjcipzLqnYlD/fP1UDNUg25dJbD8ce4WkyTi66QTmFZwBEbeBK1JxKi9JzDsRCa0Y7+25NgrpQTp/ZCrLTlVDQuquXV7kWWOhSLo3VNEk8auCRP7oS9f4bCAOXkbODSoKaElJyHjhEX4sLhT9Z+QoA70rG9Hj2nI5HB1I1fo8M4sX1U7mFGtEwrjSDlqx271XVrNQzRAtnCxeVWu7/76sL4rgqiyRjV3dgLi7v6tqPVZiIhpc38vlvy6oj4re64KJ6pKyo3EHrYkYWSbj4jVsxVl1hxM1k1gny4hJdO9RKaubCY/DQ+1SkBOvsUnhYoyBCZlHMKX6YfQMDULf8/+EypRgqFWA/zw6quYlHYIOZIRao7HiyFxeDe8JQLcPW9hvkKBahQYTDAYXfsyTDXrMOzGFuwouC4/ZBf/WEyP7oxQweLYzY6G9n20ED2yfpZ/j/dvgp+DP0WeUBk5zS9hedMtMEHE08EN8FVU+5IuXSkDEMCxExyWrOBk/6mYaMD06FFMzN8nh818gA/D+9OqIUO6D8Hcedw7KBF5Gw7gZNLDyBUs4Qsia6ejzrOVsY2/il+yz2BTfnxhyE3BzKPW1dpoeC4O96mi0asbULu2axy3Z6bg1YTtuOGXJY/T+moWflqzFdXUwRDfnQypUniJDDLOcri4Bsi9xkEVKCG8ERB5NxDaUIKjYOmpaRxWrmbRyi1Wm7p1JDzaF2DhCFwtLF4U4yjPtTYQEy9Bf9MKVu8RCbHtXe/L1TGt9QpSOVxaC6QcsYyv8gOqdwGqdRCLPa8hh8PpXwHGR167phIaPA6XrVuO5hVZ2XmaGnefpyzrs5OMMZ/PKEwcbDu2N5G+bQOIehJU0zZ9jSfpVtx1mbFnXpqLDKvrDZuyXF8lxqqQomrJqq1yXiCWNJIV+8SR9uBkIfbDb0jNyMb1G2mw+kw5ym5tH5jNaPbsf2ylLR7PcXLaB7Pou39Yldg85amPo7p0tDm9FBDN2PzLOrR6ZjQMi3+GePUCNE8MRVafARiTsAe/ZJyRrT/RKn+Mr9oGg8MauCVUBJ6DJAKi3Evp5a+cePzn8iakmfUI4FWYGNsWQ8MbF2u0ZtY5dNjwEnjmxHKz6IOiMCt0Ai6YauN6zHVs6LoORsGMRyrVwsJa3aHilPf8ZqlOlq8SsXGr5bmaNpWwt/N2LMw8J//+shCNEVPO4AT/NjgY0OVdE4LqWI7axKP7cXrmFZzTPSr/LnA6NH04HzUeikSiMQ8/p57C7PTTSDDmFT5jpawQNDwfh4ekBhjcIwA1qztmmZivw38O78S2gPNyhaDcAEzafQRPHNwHhEUi8OPpQLjjm5LpF4GTy81IszyCwxLZBKjSlEeVphz8wopX+eewhCW/i8jKsqSA6f4Ah4e683I+5dLKmr8krFpn+XejVywgnbXUDokF7hsuILCMLnbmXJdw6ncR1w9ZxtcEAg1786jTlUPiP8CheWaYCgC1P9BsMI/YViXESSj9cYu9q/blrQQ35uFpVUfiwFbQsByEJf3nvaQx7Q0Bzr6v7PuxP21xN8WNuy4zjp7Dds6Oop6zMSZOX4TB/buhbs2qnuIvF+0qpKj66sfFmD5hVGH26dI2qf1xoW0iyF5d2sjZ0Af07YxWzS1+K/Ybho7/7vx9zo6FuiWuxDljNkbvPIbROUHQDx8H/vpV+H36kvwAug9+glilBo4a0vBu6i75JytNNeH4KrI9GqstV/GdFVeO/1gwyHFp+zA354zc3V3qMPk2Xw1VcX+fnDQjuI+GIcoUj+xOT0LT8xFovn8f/LULcrLfPa3+h5VX2yIpNAXruq2FQWPA/eqq+KVqFzkvnVIlP5/Db0s5sAjfTOy3f1CHn2puwC7dDTD5NjE/Ak9NX4zdfj/DzAegbl89otvbJZaTJJg27cbZjeHIlJrIUwsNvIy6z4dAUz1EFqGbCxIwP/u0/NN8U5TyIo+aV2uiW35DDL+3CmKiLKKO3cj7/OQ5zNYegF6jBy9yeCCpIWZum4dKV89CDAmFfvQUSOExt2DIT+JweQ2HzJvxtNiNutp9JMS11uLCCR3ST/FIOwHkxhcXEaxeWJyIsDiARTBnhVnsNm/lsHuvABYSISSEObJLqF/31v9s2YZMCJI4dNCKkFioBHYs1tGMWr2dC3Gl1tS2n7wEDlfWF/Fg0dBF3c1govVF1B/gOJCnJ3Mpz8d/jv6TbcvAU2sM+36qVT0G1gTOjk5bSmNtP64zP2L7vtx1mbFv78h65+g7l82TFetzerJ/ykObCieq3N0gbAOXZtmy3/D2G4hE1Z2/zdmx3zdZR9AkORM75m+A/qPZEMMs5gD1mvlQr5oLMbYOdGOmWUwO/y90luZeAAu7kCJafGyeCqqPMWH3Iowv/fjCmahi/lwv2zijjwi5G++FtXQI8dr479Hg6kpkBteGZvx0eW6c0QDNz59COLpbbpPbYwhWYDC2xmdhXbc1yPcvQL2CKCyp1R1R/q4l+i1tBVm+OOb3k53NyQE8Ow/MwVjVejCHfxYza2aCCj3mzcSBwG+RKTRD5XpmNB5asjhg809dcBTnTzaFmQsAJxlQu9ZhVHkhDpLWki6G+Vv9mnsOC7LO4rpYZL0KzglCx6xGaKwOw3zNIVwPTZHr18qMxsTQe/HAoo8hXD4tCyrD299AjIwt9mi6NA5X1nJIO2ax5LGYSrV6Sgi72yKA7B3VjXkcMk5wSD0GsBQstoU5eIc1ZiLL4v+UlsXjj9Ucrtwos67yAAAgAElEQVR05G7UUMRDLCffzaCZzG9q0WJOTnBcV+RQv8DCSM2SDQ+S5Ejot7uwQJ6X1/LIuWQRVHX6iYhhgTwVLO6Iquwc4HpS2QvNkBAOVSyRP4oV9m//+CkLMOb1wYX/Ybet4ImocuTz664oshcw7ubH88Rlxva5Hc3XkbXM0XetglvrjumqwokqZ6ZMa/iE8WOGytYn+99tLVVMUbONMGb8jEInO/vNQqLqjtnLDidyzJCGnomr5Pe2z1mDRu0eg/HBJ4rqiiL8Pn8ZfMJFGHs/A2OfZwvfY2lHvsk4hGnZJ+TXWO62d0JbYEiwJZ2Jo1KaqJrx//18lL5fbsZuHH4f2QmttI7PevIPHkHEjLdh4lTIHj0DfrWKx6RS/zEH6rUL5L5M93REYu/3MHeHCT83XovskGyEZ4ZhgqEnerTUWHWi2wvFglAuWyGAnXBHR0loOvAGXsndgHRRjypCAH49lIxma3/HVc1jOOv3GgQ/CS3eLor0XdqAphu5uDQ7GSkZDeRqwdJ5NOh4Bdpe7QuFLXt9c8E1/JJ5Fhv0xW8OsvcC9H4Yqb4PI6pXg2byuxAuHJed0fWjJxcTVCxwJkvlkvLPzRx2wSwgpoSolrfmpSvp88yctJllK+0UkH7ccjvPtjDH7dDGQLLAYd3fQF4eJ0eO79xRAotK/ssCDlkpApoZRYQbLW3DGouoN8D1G3huL6CHDZiAZOESXAkY6u4Q7oiq3ftFzJxfdOzt7lie1m/biscLT9tZWgH5u2LB8o145+UnC11LbMfwRlTZnoZ4IqpsLV2eiCp3XWZsn9vekMHecySqnPHzdL3utHYVTlQxwKU53dmLKFbf9kyc/W4fp8rWidDeCZBE1Z22pYvmY5REdL957PfOzmN471w69B/MgKQqfjTGjgG1nw8DJ0qytUqsVjz201VTDt5J3Ym/dUly5/XUIZgU0d6hIHIkqliYgZdubMFe/Q25ff/AOpgQ0RaBnGNLEleQD+m95xFgSMexu4ej7iuPOYSsOrgN6tlfgjMZIFarC/3rE7AvJQBD89YiJTgDQblBeHJ3b/RvHYhmTd2zOKxZx2PPPosIYTGk/Ltfwssp28CYxqkrY/n6o4jZvwP5Qi3sCpoJSDwaPSsirIl742Tuy8L5lRoYzMHgJDNqqFaj+uNhEFu0LfbMjOHstLOYl3kG6ao89DI2wtf1WiJEBDRTx0A4cwRSYBD0b0+BGGNxwCoMJcCew2xxsGZhBGJaO475VFpIBdvJMJ+57IuWI8KMU5wl2rlN8Y+WkOEn4VAyj2xeDjiOCDOH5gYRKpGTncGZFSjKzdyCd+4nzfWZuSOqTp6R8OdfZS+qGjfk0fvBW/0SnYkCb0RVm5aNC4/FPBFVbAWsvlyeiCp3XGbsV9tVS5Uzfq7voju7ZoUUVWWJnERVWdJ2b6wJ6f/gu+xjaJyahZ0zV0P/zrcw17H489gX1bpfofl9lvyFrPtgRjFribXuhoJ4fJi6F1fNufJLDwfUxrjw+xAlWI6tWLEXVX/lx2NU6g5kigYEcSpMjLxfbldaEad+iqAT23BJ2wzBn01CQClB3/n489BOeQ9cbhbESuEwvPopsmJrov/FDTipSoZ/vh96bXoIjdShcqiChk6uwufls2MqvvAYq08vEbsaHMLEDIs3c3dNDGYtWIOgi6cgqTTYE7sceRmBYBG7GzzpnqCyMjDrOFz+LRs3Tlr81gLM19Ao9DcEPN0LYk2LJcu2XDXnoIYQDM5khHr6h1CdPADRPwCGt7+FWLW2nKLl2hbg+k4BkhmyiIl9QEJsR7PD23zWvl0VVfbzyUvkLH5Yx4D868UFlkmQkCUB4aLl9aBYCQ1YOhcX0saUuknK6ZvuiKo77RF9cfzHnvHf4lNFoupO29F36HxIVFkWJi2Ng58/HGaxvx1Ld8SQij6Jq1nMEGyZuxZxte6F4bnRJU/F9hiw12AYH37OYV3m9P5T9klMzjyMXMkEf06F1ys3xfBKTaCBUCiqsoxGWYDNz7Vc7WK5+n6M7owYIaBUHML+TdDOmoACLgC7+s1F2x7OkyfzmWlFDuwqDYzPj0Z+i/Z4MWkLNumuQWvQoMfGXohMjUSd2iJ6dJdQxUGi3YREDgsW8cjN5RAUKOGxgSZ8pd2O3/MtKV5eUtfE5z/OgZCSKFuFzt43C/H/REJTScI9b4ry8Z83JfsSh3PzDNDnWURqrGEV6jQ8BnHAs7c6nJvN0Ez7oEhQvTEJxpj6t6RnqdJeRPUukhwqwVnxVFTZ9susVuknONmKxaxZtiW2s1k+dvw3l/Isqjx1VHfmeO7s9p8zy5Wz23/OYjU6c5lx1t4qDNlPZi0ryVJGjur/5k++G89OogqyIzPL/9awgYjBHlor3EDutCo7ouqUsAJXTDl4e9cxjD1wAbqP5zoN/lh4DGg2Qzf2h1uOAW0HZsdRn6Tvw7Lci/LxDrOcMKvVk9F1cSA7Gc8mbMYlU7Yc92p05Ray6OKdBGfgs9Kg/nAIBEM+lkSORbcPurgcsdvegd3Y8yno+z2H15ItokgtCui6+UHEJlqct+9uIqFbV1EOJMrKwSM8Vv5uEQGxsRL6DtThpdz1OKRPhQAOXwj1MGTKN7JFTAqLQurAKTiy0OLN22SoqKij9ZW1QMJWyxGtRkxFnGEyKt8fCVPvZ2Uxx8JiaH8cJzvrM+d2/ZtfIeFqQ8Rv4goTCUfdK8r56Jjgc7UoIapsx2IWuIyTHNJOcajSTkSIizG3XJ1veaxXnkUV4+0spIJ1TWwDg7oSIqG0OFWuhEgoLU6VM1HG5uzMZeb98TPw2ZihJYZDcBanikIqlMdP622aM4kq4JPxKvlqOSv/eVpE3TqeHQMptYSfpe+XncvjMvKw66eVMD41EsYOfVzqXr1hCdTLLeEVdB/OdNrmkD4FY9P2FIZgaOUfif0FlltpdVUhmBbVGXdp7AIcldCr9tt3IJw5jMN+nZEy8EPc39Z9fxL1qjlQr7E4sJubtYPh+ffwv9xjmJFzUn7t6fMPQLvLEuWcldatRLAYVPsOWARVq5YimvTIwNNJG2VRyo4sZxZURffp34Az6GTfrYLhX+Dgz2HQp3Ng6U5qP6z8erOwB2d/BfKTLA7DUcataMj9BL77Q+CunoHq0N8QNYGI7/4DLh+JhTH7pvP3XSJqPeSZk7XSosrp5vkXVijvoqq04J+OllMJMcFEWYfWTQvD+ri7bZjg2rH3qNvxs6zjeNue9eOJv5m7z3mn1CefKi9X4t8uqi5e4jFnXtExR3i4iJGvKv8l6+oyHdSnoO/1P+XqO2avQVxAFPTvTnW1uVxP++XrEC6dgrHHkzA+8oJLbVnqlU/T9yGDXRMD5BuCH4TfCy3LYutCUW9ZAfXiacgUwvFDzVl4ZVQA7PzpXejFUkX1z1Zofv5M/jsLFcH8rKbwSYVJpN/h28HvrzgkJhb3/2GJgo2NE/H8jU3IFo2IFvyxJCkQd8+aLPdljmsBw7D/4fzqINzYx8M/UkTzN9xP9Ovyg/z/kWPiDh5X13MQjRxUUjYa6KajqnEdrvv1woXw16HL8ZO7q1TfIqYCq7pumbKfB4kqd1bGs7rlXVSxp3YnTY23fkTO/LhcWQVvRZm37SlNjSurRHUKCfzbRdX6DRx27hZwfzszTp3ikZ7BoVcPEW1bl72wYkE1u177XT52e2vPSXyw7RB0//1Jdl52p/ApidB+/AI4sxn60d/BXKuhS81zRCOm5R/F/ZoqaK9xPWownxQP7WcvgTOZMD38G8T1a4r7vLwZZuvALgUGw/DaeMyP4PF26k75Wd4OvQfdE5pjw0YeRhPw9CARf4ecw6iUv+X3m2nC8evhVFRZtVD+3dSqi+yTlnlOjZOzLCK66etm2fHa14X5KZ1fxiHr3M2QCFI2jFyIPCwbv+ZDysR5IlHl65WsGLn/fE+JRijPBMhS5eXq/dtF1dTpApJTOLz4vBkGA4dfFvDQaCS8MUKUnZ3LsnyUvg8zsk+iYY4ef/+wDOjwMAxPvuZwCkuWCbL4Y0lxHZXCY8DoatB9NNvlx3AW/NNRR36fDQN/7SL+DngUW2uOwJuvu3/s56hfWwd29r7h2dFY1awBhqdsA3O4ZwFNv4y4HwUFHCbrDmBq1jG5m27+1TDnr4MI3LVB/p35Zxn7PQ9zPod/vuJhyuVQo4eEal2UmaercFmcqYt/cGC+SvaBO13to7R6JKqUoFh6HxXBUuV7SjRCeSZAosrL1fs3i6qcHA4TvxFkEfXBe5Yv2HkLeZw7z6PFPSIe6Vt21qoDhmT0S1wjz2HrnDVommuG7tP5kNiVRLuybz+P1Wt5VK0iYfjQEoSBJEH7xWsQrpyFsftAGPsPdWmnuCuqWBgHFs4hTVsdk0J/Rt9HVHJcKPuStJuXI3i743jN+mB+UJqZnxdGYDd2fRxbevfB88lbwIKb9g6oKaeIWZtvCa75SkBDfPzrCginD4HlpDE8/SZM7XrK7536hUfGCV5O0dL01bIVVFYeLMp51nkgopnygp1ElUtb3KtKJKq8wkeNywEBElVeLpIvRFXDKwuQKxmxJKYn2vndmrvMyykr1vzgYR4r/+ARFydi0ACLEEhL5zB5qsWP6OWXzA6v7is2gZsd6SQTuiT8LjtWv3XwIj7YsBv6Ie/B3KrrLUNlZHL4bpoAk8nyVotmIh7p51j8FR4DmkyyX5Yrx4DuiCrh4gloJ42CBB5fR/wEU0wtjHjl1rmwuEv7xgkQtBLqPCIhsoX7YtU2Aru50T3Y/8JIDErfJsfPspavA5vj2elTIVy/IsegMg7/CKYmreS3mZXo3GJejvN0z5tmaMOUFzVK7wt3+yNR5S4x9+uTqHKfGbUoXwRIVHm5XkqLqn36G3j0+lp5Vr0CauDnqC5eztB3zX9bwuPEKV62SDHLlLVY/ayqV5MwdIjvLRr/TduLWTmn0KBAwt4pC2Fu0Az6UZMcPviMWQLir3GoVUtEQgIv31pkAS5L8mFSb1wK9bIfIUZUgf7DnyGpNaUCdVVUcfoCaD9+EXx6MrZEDsGfqmfw5AARjeNuFUzxGwXEbyhyKmdRy+s95lrsJdvJFovAHl0NJ179AI8V7AcTpbM0zdBlyufgM1MtkclHfFEYeJP5NB3+mofZwKHuoyKi27gv6ny3C5XrmUSVcixL6olEle8Z0wi3lwCJKi/5Ky2qrMl/rdM6UH0AqgilhNT2cv6eNmfX8D+fKECv4/D2G2aEhBRZLljy2G8m88gv4PDYo2Y0u9t3Vg2W+qX/TRG6Zd56NLuRYUmYHFHllkfbuZvH+g28HKB05AgR8fGcfFzJccCQ58yoWd3BPG2PAbv2h/HxlxURVZr5X0O1cy1ywuvhY/WPiIrm8OpwxwKUWamYtYqFLojfaInFxBLxsrxxoY3cEzjFHNgDgnDl5bHIEQQ0+W4ceJYeJywK+jcmQowscrQ/9oMgJ9mt1EBEkxfcG8/T/XU72pGo8j11ElW+Z0wj3F4CJKq85K+0qHr4+p/4R5+CmupgXDHmYETI3XgvrKWXs1S++dV4Dj/PFhAZIWHEK7eKgX8Ocvh9tSA7go8aYYbacZo7rybGfIK6JKxEvCkXo04m4cNVmwqdqu07Tknl8f2PPIsbiWeeElG/nkUcbN7GY+s2Hv7+Eka87NhxnU+9LluVWIBN/dvfwFz3rhLn7YqlSji2B9pp/4Wk1mJK1VmIN1TFM0+ZUb/eraIueT+P80v5QkFjyuNwbgmHjFOWm3AsfxzLI8eO5VwtFgf2sbJzvG1hOQ/1r38BKbgoinvidh6X/+Qh+Eto8Y4IdRlfPnD1mZSoR6JKCYql90GiyveMaYTbS4BElZf8lRRVLO1Jwyvz5RltqPMwul/8A2G8FsdqDPJylso337SVx7btPNq2EfFAdwOYRAngihIVM0vW9J8EJN3g0LG9iG5dlLdwjE3bjbk5Z1DPpML+r+bKVhZ2U8/+iI7NZdqPAm4kc2jRXMIjDxeJQPYes1adv8CjSrSEl140Q3AQWkq9ZTnUi6c7PQZ0JqpYRHK/cS/IkclPtnkLs670QdWqEoa/6MBKJQEHJ/HQpfJo/IIZlRsUia7kAzwu/s6DuURpQyU0GCQiuKbrFkHmwK6e84UcRJMVawwqSVuURqcgmcehby3JiD1Jlqz8rvNtjySqfMuX9V4RRJU7cap8T/TOH4HiVN35a3RHzVBJUbUu/ypeSN6MDgExWFfnYbQ+sxTHjen4NqI9BgTVu6Oe+8efBbBccc8ONmNb5El8nXkIL1RqgheD4xDCW/yOriVw+GmmAIEHRo4wo7IbKUOcPexOXRIGJq2TU6hsXrwNTS/Fw/Da54WO1bbtmSWKWaSY1eyNEWZo7Kw6BgMwfQaPtDQedzWWMPBxx8dwfpNGgb9wHMYHHoVx4CsOp+hMVGmnfyjfxDM2aY2P8sZDr+fko8daNW4VRBmnOZyaLcAvQpStRPaF+TqdXcgj5yoHlgGnaiczaj0owcV4o3J3zIGdS78Bw3PvFuueJSI+MkUAi2we2UJC/Sd87xvnbM19/T6JKl8TLv+iqrSI6t5GDWeBQidOW4TxY4citFKw24vhbrR3RwPYJ3d2dxIlMfCWjbvzuJ31yVLlJX0lRdWYtN34JecMPoy8F+9Gt8DMpNN4PXU77taEYV3Vh72cqXLNdToOn39pEUsfjDGhTeISJJrz5AFYguHngxvipcp3I5L3w9LlAo4e5xDXUMSgJ5SxVrFjv84JK5BgysPIazp8tGCZnJJFP3zcLQ/JLGU/zBAgisBzz4hyQmFHhd0K/H66AIMR6NldRLu2t9bj0m7A76Mh4EwlHwOWJqqYDxXzpZKCKmFDt9n4a2+ofOTHjv4cleM/Cci+wKHe42ZEtSrBCiWxPHkCrjBHdjPgHy2h0dMS/KO8Y311HY9rW3iogyW0eNv7ZMnK7T7f9USiyndsrT2Xd0uVs9x/Lwx6yO10MLZ59+6Oq4PpE0a5Japs8+5ViQ7Hj1++VWKOvpJW2Db34Cejh6D/Qx3d2gy2uQcdMVAiXY9bE7qNlUlUeQlfSVHVPmEZLhlzsKnmw2gTHIPk3ALcc/U3+dr76ip9cI82wsvZKtP86DEOS1cIsiDQPHwab96M0m3bO0vP8kRwPQxRN8OiqSFy1O4Xni/BGdzNaY1O24UFOWfRAP7YMWk21LxgcU4PiyrWk9nMjv14MH+q++4V0eeh0oUGi69ldVxnOQwdCTDV5hXQLJlW4lFjSaKKS0+2HPsZdMh+aQLGr2st3zxkzunRUbcKJmYhOvyNIPsw3fu+GZyTbDd5iRzOzOehS+PkujV7iqjaQZQtWO6WnCscjk0XwDJF3zVMRMhtzuXo7vw9rU+iylNyrrcrz6LKKl4G9O3sMA+ft9aYimypYjuE8WHFXcHm+u66M2qSqPJyHZQSVYmmPLS6tgQhvBqX6z8LrVpAZq4BEzIO4ruso3g8sC4mR3bwcrbKNF+2UsCRo5Z0NO/ELpXTwnwf2RGPBNbBEUMavsk4hI0F19h3MlTg0DavDqI3tEA9TTBeHS6CL0oV6PaEbI/9Nv15CM2On5Dz87E8ffZlwyYeO3by8rHj66+aXcqlx/zEmL+YVivhteEiKtkfWbLbgJNGgcWYMnXsC8Og14sN61BUiaKlzaWTMN3fC79Hv43du3k5fAILo+ConPtNQMpBDjUeFFGtq2tWJ8kEXPqTR9IuC+Dg2hIaPCHKPleuFuajdfArAYZMDlU6iKjdx7WxXe3/Tq5Hosr3q+OOqJIy02FOuOz7SdmNwFcKA1+t1i3jOsvDR6Kq9MTJzJq1ZNVWjHtnCPz9Sg9NU+aLruCAiooqR2bIqtER+N/EWWjTsnGFVKhKiaoFOWcwOm03+gTWxLxq3aC5KaqY2Gp9bQl4cDhSYxAq3/RXUnAPuN3VhImCHC4h7qXzeFu3FdWEAOyJ7gtOUxS9/KwxC99kHMbq/EuyEztTWLWu1sSrQffgqZZFt8vcGZzl1uuUsBw3zAV4PVODcT/OhlhCGhnm78X8uZgjOkuhU8NRuIQSBmepdpjjemSUxYFcXeR/L7fg0pLgN47dBtTL8bBYXCxrcSSq1OsXQb1yJqTwGKS9OQNfTguS5/XayyIiI24VLcZcDgc+EyBxQOsPzBACXBdFbB5Z53mc+ZWT08mwgKG1+0mIaumaOLqwTMCNfVyZJEt2Z+3Loi6JKt9TdkdUGbavQ/7UT30/KbsRNB17IOC1/94yrrPkyCSqShdVzviV+UL7aEBFRZXVya1XlzaYOH0RBvfvJp/tVmSFqpSoGpayFavzLuOL8LZ4KaJxoahi6/5i8mY5jci7oS3weqWmPtoKrnV7PYnd6lMhJFjCmoHLcMaYiS9T/PDir4tg7NgHYpf+EEPCCju7bMrGlIyjWJZ3ESaLvEIHTSxGhd+N1lr3osWzY8bfcs+hFh+APZMXQpufB/0738Jcp0mxybNo6SxqOvOTattWRK/urgkKaye2jusl+YKptv4OzW9TLceALCio1iIo7UUVn3ARfp+/Akgi9G9PxoqTTXDgII/mzST07+fYl+rKGh4J23hEtxZRt797c7c+g7mAw7mlHNKPW6xWoXEi6g8oPWBo5lkeJ2fy4Hig2UgzAmLcE3Ou7aA7txaJKt+vjTuiynR0P3TLf/H9pOxGUDVtBb/+z5Ko8oB8acKSRJWbQG1vHjDrlK2o8vas2M2plGl1JUQV++pqfHUBskUj9lcbgHqBIcVE1d+663giab3s+H2wxhOy1ep2le1/89i4mUdAx3h8V2s9wnktjv+0Cn5pKYVTMrXtAVOPJ2UrkrVcN+fh1d3HcSDmLMwqi5hopYnCyNBmeMA/1unjbClIwNM3Nsi3/dbsu4H7tmyAqXW3W26tsY7Wruexey+P0MqWYz9HIRKcDcgEGfPHYrfzuj4gohPzT7IrhbcB2z8E4+BRDkWV37gh4JPi5ePJ5M4v4tvvLM5Rb40sHjDV2rVoBPZ/LMjRy1u8Z4afG0d3jp4p9RCP8ys5iDpO9s+q/6SEyg1ufRY5WfJEXg4sWqOniGoPeCbmnHG9k98nUeX71XFHVPl+Nu6NQMd/znmRqAIUs1SVJqrIUlX6ZjxsSEXvxNWoqQrGrmqPIUArFBNVrHW7a8vk3HYzoh7AQwE1ne9uH9WYNVfA5Ssc9j+9Gkf5JHyYHYxR039wOJrprvtgfnAgzPUtx2PJKRy+mmPA0bijOH/XaeTDKL9+lzoMI0Kbys/lSDCyY7/215YhVdThNXM0Ppn0NST/QOg+nivfpLMt1qCkLEr6Sy+YEVvVc2vLxUs85s7n5aM6RzcH5duALCioQSdHITc3bF7MUqVZMh2qzcthrloL+rE/YOnvGvkmZGlO89d38rj0By9bluKeU0bYGLI4nPmVl6OisxJ1r4ja/UQINm4Np+fySD/JI7iGhLtZMNfbp9t9tHOdd0uiyjkjb2uUZ1HlqaM6+/776sfFTm/1lWR8YK+/P34GPhsztNRbfSWFVLDO2xUXHEchFdxpX5qoIkd1Dz49DNqef05izOuD8d2sFfLxX1jlYLz83jcY2Lcz+VSVwHRK1lF8kXEQzwQ1wISIdg5F1dyc0xibtgf3+8VgcUxPD1bH+yYs3MDnX6iQGp6KFb1Wyk71x+duRnDiVRiGjIGpVRfwKQlQrVsEYe8mcGaLaDLXbCCLK1PzDli9ToV9B3iE19TB/MgJzMw6UZjUt64qBK+FNkX/gDpQsTOom2Vkyg4szbuAWqog7J6xGn7JCTAMGglTxz7FHorNb+o0AZlZygUctVrmmOP6K8NE2fplW1TbV0Hz6xSIlcKhHzcboRGVkK8zwXjiELTfvA1JpYL+gxm4IdTA1Om87KT/1htmBDmKTC4B/3whgMWfavKSGZXqei4Ib1ltCUj8m8eVtTxYDCrbgKHJBzicXyJYkiW/ZXbLsd37XXXn9ECiyvdrUZ5FFaPjLKSCleCcb98rvCHIhAorbw4b6BCwbUgFawXbsATW79WSHLxtfZmt7Xt3bVPoEO6KKLMNqcD6sA3N4Ep725AKjhhQSAUvPlvO4HrR9R3ZVInjvwFJ67BLl4SfIh9A78CaDkVVgWTC3VcXgf3cEvsoGqiLW2jKAs6pMzx+/Y3Hjt7rcTY8HqMKQvHhFItfUcEn82B7rY9FDFdtXAomOrgCSwwrMbwKCjo9jkkHH0KO3g8D+5tRp4lRjor+Y+YxpIg6uV6sKhAvh9yFp0IaYFdBUtGx3wUO9y2dB7FGA+jemwo5aZ9N+WM1L/srMefvV4aLchwtJQp7Zvbs4eEiXh4qQmN3cUU78Q3LbcB2PRH0yhgUZGRBev858NnpMAx4GaYu/bHwNx6nz/C4v62IHiX4eDH/p9PzeATGSmj2um+CbRbc4HBmIS8H9WQlpp2IlAOcfNxYb4AoW7H+rYVEle9XvryLKncDbCohJpgo69C6qcMwDq6sGPtO3rH3qNvxs6x9e9u+JDHqytzLYx3Fjv/K48MrMWdvRRUTSfVupqY5XWMwgnk1AjkjVKlJyAqvXmyK/03bi1k5p/BccCN8Ft5Giem71ccff/LYcCELyx9eBj8IOLZsPyLOn4LxqZEwdihuNbJ2zI7GhF3roPprMfgMi9+VURuMbap+OBT9GIa/GVTo88SscVMzjxUGEo3g/aCHGez471V1bXz6qeUmkG7MNIg16hebOzuqmzPPYgkaPtSMmGjlrDwsxtYPPwtISeZQr64o5w601XPsubQsBpW+AJrRE6Hfvg7cnk3ycSA7FmQ3EVkEepb/cPQoM7R+jud2bJoAFiOqwSAzIporN39Hi3x5LYfErUXBryo3FNF4yL9XUDFGJKrc+ufAo8rlXVSxh3YnTY23ztnO/LhcWQRvRZm37SlNjSur5KCOuwrew2HuuGbeiqqtukQMTvoLLT2M2JIAACAASURBVLSRWFWlt3xN3++dgeD0+TAOfgPG9r0Ln/miKQsdrq2Qc+wdqvEkgmxy7ZUFmEnfCPi9+RZcrH0RLxkj8MXXk+WbfrovfnNpeNW+zVCtXwQ+8VJh/St1eyP62cchRhU5tf+Wdx5TMo7gsilHrldfHYLdy/ZCOHUQpk79YHjytWLj6fQcpnzPIzeXQ5fOIjp3VF4cZGVxmPqDxXGd9c/GsS3qv9dAveCbwpdE/wAYPpwJsXIE5swTcPEShy6dRHTu5HhuufEcjk4VoA6RcO97zoN9ugTcSSUm4M7+ysOkQ4VPluwKLxJVrlDyrk5FEFXeEaDWFZ2AYpaqO0lU2Z9R255vO1pQ9r+JYaO/wvUbafLbJYXpd/Q/FG9F1Ufp+zAj+6QcKoGFTFDt3QTNnAnyPMSQUOg/nV8sQfCgG39he0EiPg5rjRdC4spsf6amcfh8bgEWP7oIAsfh8LpTiD3yD4z9X4Kx+wC35iEc2wPTmhUIvHywsJ3pno4wd30U5rp3WZ4dElbnX8b3GccwKc0PradPtPAYNxeSX1E8LFZ32QoBR45xcmTyV4aZ7U8F3ZpbaZVtHdeZtap+veICSfvtOxDOHJa7MLz4AUwtO+HyVQ6z5gjw95dkXyr7vIPW8Vg09LRjPGr1llC1o2+O/hw9m1nHoSAFCHIjjpdiQO+wjkhU+X5BSFT5njGNcHsJKCaq2GN4ayZUAoX9TQVnTnZWAfbWsIHymbX979Y52fqK2Yo0b0VV14TfcdqYgaUxPdHWLwbaKe9BOPWPLBw4XQGMjw6F8cEiB8e/8uPxfPIm+abgzmqPldklLRai4P2snTjT4AyeRCSmf/EtpIAg6D5fAEkb4NHSrZ91CTWP/4YWBZsK25trx910am8vv8YsdtqPhoDPTCt0hrcdzJpahheAV4c5Dqbp0eRKaPT3Lh5/beRlcTT8JRER4UXCimepaD55EWKzttA9N0bugR0bJiZy6NFNxP3tHFup2O28A+MFOb3MfR+a5YCdVMqeAIkq3zMnUeV7xjTC7SWgqKjy9vxYCRT211KdXQe1F12O6lv7HP3qIIwdPwNWAcbm642oYiECml1dBA14nKv5NDRZGfAb86QcLkA9/H2YvhkLdoyk/3SBLGBYYRac1vFLZb+jhdHd0cmFGE9KcP1+qR4TWvwGiRex5+8ENNi5FcaHBsPY9zmPu2e39FjcphBjMl6p8StCj6wBZzRYnjMyFuYHB4C7dhGqbX/A3LAZ9G9MKjZWQYHl2C8vn5Odv5kTeFkUq+N65coSXn1JLOYjVfnUbujqN4NOFYAzZ3ksWMTLN/3eHFlympxLq3hc/5tHlfYiavctm2coC07lbQwSVb5fMRJVvmdMI9xeAoqJKkfXQm0fzZPs256gcRQTxNmVVvb+ms175ezerEyctgjjxw6VM4Xbii5reAhbUZWUbrmx5klZmnMBI1K3o2tANcyP7g7VhsVQLfsJ6NQb2hdHo2Dca+DPH4OpxyCYHn2hcIjvM4/h04wDeDCgOuZGd/NkaLfasMTEvdbtx7HGx9Gbi8L8Cd/IR5KG8YsgBYW41Zd95b82cWBhCyIjJLz+XA7Uu/6E8NdicDmZxaoaxrGUNMUd9xcs4uRbeSwW1fAXizuPezUpJ42Z4/r0GTySkznUqS3h+WeKxg4NUiNfb4LeKOHbqTzYsenDvUXcd69j65NZD+wZJ8hhDu4bK0Jjn2vQlw9CfRcjEBPmB28+z4TTOQHGmAoRqMgEFBNVdwokR4FGnYkqWYj98BtSM7JlvyqrT5W9n5ijo0GRRYb0sPzn8mbMTz+Lr6u1w8iopsh96xmI1y5jRvQUnOHvxphHziF8+kuAWoPgqYvBVQ6XR0o361Ht6FwYJBGX7noa1TUWK5avyr6zerTP/EWOhL7vSCbqr/sTmocGwO8/xZMJezI+Swnz/qcmZGUDTw0Q0Pl+y1V/4+bV0P+xEOL1eGgffQbaJ18q1v3+QxJmzDXLN+r+964KURHujV6QDogiEOhmO+soqenApxNNyC8Aenbl0L+v5SYdx64FSsD+QyJ+mmtGRBjw+Yd2yQNtpnruLwnHlpgR2xJoPbzkeu49HdX2hADPcfDm8+zJmP+2NowxFSJQkQkoLqpud5wqdy1V9seFVuHEgpU2a1KvmAO77Uaw+lV5c/zHjv7YEeDm2H6Iu5EOv8+GQx9SBe8HLpSHatRQxHOZH0J1eKecV884aGThFKx58Fg8pw/C7vXpHh3+zxGsCj+EZrkR2Pr9ZHks3fhf5ZttSpTDRzksXynAz0/CqBGi7NRtLarDf8Pc5L5izvq5eRwmf8dDb+DQu6eI1ve5d2SWuIPH5dW8nKj4npEiNHYBPV19pivxFid0pqsHDRQR10iUI6rn5psw4RsOmZkc+j9iRvOmJQvv/Z8KMOZwaPqamZzFXQXvo3p0/OcjsDbd0vGf7xnTCLeXgKKiypGgsd6se+U//cokorq7PlXuWLYcWao8FVWnDRnomvg7WCymIzWehGbJNKg2r8CROs9gXsGQm1YP4N2nLiPiqyFyoMuCj+dACq8iv3fckI4eiX8gmFPhaM1B0KAo5pCSW0onmdDk/GLo1Ab8eqAAPTctB8vtZ3j2bSWHwY8zBSQklJ7CxTrgLwt4nL/Ao0Y1CS8Ocf+m3JEpKuQlWHrzj5bQfKTnIQx27eaxbgMPlQoY/qIZjeqqsWWHGcv+4GQn9hGvlHwsmXKIw7lFAoJqSGj6qvvPoegCUGcUp6oM9kBFEFXuxKkqA6R3/BAUp8rDJSotL1JZ5v5zdvvPKvLGjxkq3/az/93WUtX/oY7FaCgpqn7KOoFxGfvxeGBdTA5vB/93nwCLQj4xdgFuiFVRtzZw4RJwf1sz+l6fCNXu9TDd+wAML4wtnNPD1//EP/oUfBV+P54MLh4M08NlvKXZt8knMDF/P6LTQ3Fq9g/gTCbomH+TTVwpJcZKvM7hhxkWYfjacDOiohxbdw4e5rHyD8vtuxGvmFHJTR8kXSqHgxMtKVlYTCh9GoeI5iIaDHLP2mX7zEuW8zh2nAdzXB/9uoAJ35iRncNh0BMi4hqW3O+RyQLyEjk0ekZE2F2ej68Ef+qDgn+WxR4o76LKUegg+xQvJYXkcca3pNx/ztpZ31cirJGj3H+ujs/qlZT7r7ScgO70Xx7qKmapKm1Bvd0s7oIsLU6VvYhifdsfWZb0oVBSVD1zYyM2F1zD5IgOeOJiMrTTP0RulSb4CFNlp+0hTwv44lvLUdj7Q29A+8HT4Mxm6P77E8SqtWUky/MuYMT/58VjCYnXxz7sLian9Y2SiGaXfkMWr8fn2yW8vHshzC06QD/0Q6dtPamw8nceB4/wqFVTwpD/3Gq5YbcFWf48g4FDv74iWt7jvhCJ3yggfoNFSFXvChyZwkM0ArX6iKjawf3+2HMyx/WfZwq4foNDQACQnw9UrSLJkd1LKlkXOZz40RLss9XYf2cCY0/2iC/b0PGfL+la+i7vospeHLD/xE+fuxLPP9lLvthUUkie0sjafl95cqHLNvefbc4+d1bTVhh6Igptv0Nt8xZa56BEuh53nud21lVMVN0plqqyhunJ8Z9JElH/ynwYIMpHf1VnToTq4HbsjXsDSzL74cGuQJ8ePL76zgzmt9Ovj4g2l6ZBvXGZ7F+kf+0z+TFZP83iF8kJif+o8hBaaqMUffx5OWfwXtpuhGVUwuk5c6A25MvJgc2xtRQdx9oZ85X6dooAlhj5yQEiGscVFzmzfuFx+TIvp4p5drBnAkhOWJzOodFzZoTFSbDm22MBv+4eZkZwbc8uHjDBN/0nHizMAyv/eVpE3Tolz/HUbB4Zp3nU6iuianvPnsUni/Av7pREle8XvzyLqtK+42zFw/8mzkKblo3ddnfx1vhwJ1uqZCPAmu0yJvsTIN/vurIdQTFRZYW2eNVWTJ8wSlbtrJS1T1XZ4vMsThVLnsySKDdSh2JzRHf4vdVfnvanVZcjyxSCd0ZKqB4rYNd+ExYt4REZKeH1ZzPhN/YpsFx6ure/gXgz8viXmYcwOfMIHg2sg6mRxY8rvWHB4mG1vbYU10x5eGWDBp8dnA1zXEvoX7dEe/dV+XuXgL82cvKx3lsjiyw9+/bzWL2Wh0Yj4Y3XRAQFuS9+cq8BR79TQfCX5CCb3M2Ey1fX8bi2xeK43mKUKFuPPClXrnKYOUdA7ZoSnndgabP2qcvgcHCCAEEjodWHZvkoksrtJ0Ciyvdr4I6oumEqwKmCDN9Pym6EaLU/4vxCbxnXlTx8jk5CXH2Aii6qytINyFXmvqinqKhiE7zdt/98Aam0Pj2xVH2RcRBTso5iaEhjfHoiGZqFk5FZrwM+zfsYYWESxr4FaNQCMnIMmPi1AGbBee5ZMxqenAf1qrkQazSAbsz38rRSRB1aXF0EHhyO1BiEyrxGEQQr8i7itZTtCMoNxKmfFiPImAndqEkQGzRTpP+SOhHNwJRpAtIzinLlsb9/N00Ai5fl7DZdaZO7tJrH9R08oluLqNvfxjokASd+5pF1nkdgVUm+iceim3tSjh7RoEoVMyKjSj76u7icR9JeHlU7iqjVm6xUnnD2RRsSVb6gWrxPd0TVvLSzePZyUbYF38/OMsIzYQ3wS+2utwxXWnBr2yM8T47P2GAVXVTdCcHBy2IPKS6qymLSd9IYnoiq3omrcNiQhnlR3dBr+lcQzh/H1uafYPWN9nKy3j49OFlUZeYasG0Hj01bePm6/lOP6uD3/mA5MKb+5Y9hbtpWRjEsZQtW513BO5Wb443Kzb3Gw+w0XRNW4owxE89sC8SUPT9BrFEfujHTvO7blQ7OnuMx/1eLGemdUWYs+I2XU70wp2/m/O1RYbGjPhFgzONw1zAzQuoUt0axHHiHJ/Py0aA3jusspEK+zgSd0fE8zfkc9n4qgJOAlu+ZKdinR4vpm0YkqnzD1bZXd0TVhuxr+DzpH99Pym6E7iHVMTamhVuiylrZWQaP0h6GRFWZL7VPBiRR5SVWd0VVtmhA46sLIYDD+eBuqPTBc3Jamv9FrUC+QY0Rw82oWZ3dbrOIqvx8DhMmWcwmLNVJxKGV0Pw2FWJ0Neg+nAnwPHbrkvB40jpE8n44WOMJ2WrlTbHmFwwwaHFo6hpEGZOKiThv+na17S/zeZy/yMvHfLm5nBzDauRrIgIDPDuaszqGs4jl945x7BhekMwXOq7X7ieiSgm5+kp7BmeiKn4jj/gNPCKbS6g/iMIouLofyqIeiSrfU3ZHVPl+Nu6N4MrxH+vR05tuJKrcW487tbaioopdx0xKTse4d4bA389yDOWNcr9TodnOy11RtTrvMoalbEU7vxisPJAM9Z/zkHrPI5iQNBLhYUw4mBGgFQpFFRtrxe88Dh3hcX87M3p0McH/w+fApSVB/9xomFt3l6fzQMIKnDVm4YfIzugb6J0jea/EVThqSEO/3aGYs30qzFVryg7qLFZWWZXUNF7O62ctgwaIiLNzXHdnLheWCbixj0NsJxE1HyrZ2mXruN70FbMcQ8qdUpqokkzAgc8t1rLmo8wIiHGvb3fmQXXdJ0Ciyn1m7rYoz6LKkaM6E1qzF63Fy/95RP7OcxSSx1H8RkfcShJV9vlpS2JekqO6O9/BjkIquNO+NEFJjupuflro9p9rwN5N3YX5uWfxbmgLvDtxoiyO1raZik1XmqBzBzO6PCDdIqqSbnCY9qMgh1cY844Zqn2boZk9Xo5orv9kHiSVCtabem38orEsppdrk3FQa6fuOgYmrYe/pMLu77agZsFV6Ie8B3OrW30MPB7ExYZr/+Kxew+PpneJeNzWB8rF9oXV/j934d5PBJgLODQbaUJg1dI7uLKGR8I2HupACc3fcM9xvTRRxUQdE3eV6khoMoysVO4uo6/rk6jyNeGKF1KBEWNCZOavawrh2ftUOUuT5ihvrm1YAiZG9vxzspixwnalbEMqWF/v3bVNYX1XRJl9rC3b0AyutHfmS00hFTz4bN1Jcao8mL7HTdy1VLWKX4JEcx7WmuPQZtIHEMNj8EHQQjn20ivDTIiJxi2iik3u59kCrsaz5Lxm3NtSgvaToRASL8PwxGswde6HAsmEe64uQo5kwpbYR9FAXcmjZxp04y9sL0jE4xciMGPpZOgCoyB+OU8+ZizrwtLQ/DCDw7AXJfhpPbfqZJzicWoOD22YhJbvuiBm7BzXm71mhqsB60sTVQcn8tCl8oh7TkSoF1a3sl6Hf8t4JKp8v9Ll2VLF6LgbtkAJMcFEWYfWTeVg1Z4UJnh27D2KN4cN9KS5fPnMm/ZsUE+PRD2a8G1upNjxH1mqnK/kJWM22icsRwivxvkdyVD/vQZJ7Yf8X3tnAiZFdbbtp6p6NpB93/cdAVkENRJUohFFI0bE4IoiAROjIAiCATXsIkaNOKKIMQqiokZFvygKqMi+r4Ls27BvA7NV9f+fGnvo6emluquqq6t56rq+68tM19nut5q5PefUe/D8L/cULf2JWgKX/8TvNm6S8P6Hip5e4a8DVSgblyHtlZHwlr4EOWPfgzctA2OOL8P005tw9yVNMbHylZE7FHCHWPITS3/pULBg2nI0O70ZJ275G9JuvDnquqwqkJ8P/dBkM9fP7yk4ulZCnetFwk9jG93FxvXVU2XknZRQtYOGxr2NlQslVSe2Stg8Q0FahV/FLn4rqWbQXVRlKVX2h9vtUiUIRXNMjdk33ozu4woXObNSZrY8j6kx8b0SD9uI8dOROWkIGtUrXGNhnqoLQP99ZitGHPsJN2XUxTvjX4SUex4fXzMHP26pgq5Xa+h+TeEf7mBSJQ7t9aVXeOBeFQ3qe5E2+TEoOzYiv+d9yO9xN3YXnMFV+z5CuuTB6jp3okyUCZAeOvwtvjy3B32zq+CVV15EtlIO8ouz4PWYtBoTz5TZomIf05K/e+BVgY5PRfe23blDEta9ougZ1xv+QUP1KyKLVSip2jhdwantEhrepqF6l8j1mB03y0dPgFIVPbNoSySDVEU7Zt5/cRGwbKbKh80nUQezjhWRnPni8JinLhM9HNEs//mkZdLZSuj/r5egNmmLp/Om6kt/Ax8uQI3qhaMNJlXi9wu+l/HtdzJaNtfQp7cGec/PSB//CLyp6ciZMFt/i/DurK/x3fn9GF2hEx4u18owvp0Fp3H1vrn6W4kLPtyOVr8swdoWD6PJo3cYriMRbzyyRsK2WbEfWly0cV0B2vw58sb1YFJ1/oiM1c/LhUlHR6mQPIlIin2iVNn/DFCq7GfMFpwlYLlUOTuc+LduVKrEjqCmu/+Dc94CrJ2/C3VX/Ii9NzyBf667qUT28FBSJY5AmTRFgeaFnm28bFkv0l4bDWXtYuR3vwP5tz+Mb87txX2H56Oepwx+rH274eQKfzv6PT48+wv6yNUxbfwU5EoZ2DJoDpq0To8/VAtb9B0H06CnhhoxHgez6wsZBxb9unF9sIaUMNncg0nVtvcVHFklofZ1Gupez1kqC8NraVWUKktxBq2MUmU/Y7bgLAFKlUn+RqVqZe4R3HLwC9STS2PNxDfglT348Nq5WLq+NLr+RkP3ay/8sQ0lVaKrcz9VsGathN9cqeH67hrkrL1If+ZBeJUU5Iz9D7SyFXD5r5vhRXLRa0vVjjjCLPWcXkaFF4t/OITmP87H/EvuQYdx9yLVvSt/0BNtPluY46vTKDWsDIWF5AXWZyo4s1PSUyyIGatQG9cDpSr/rIQVYxV4JegHJ4cTsoiB4g22EqBU2YpXr5xSZT9jtuAsAUulyj9PlRiWOFjyi/lLEOvJ2c6iMda6Ual68eQaTD65BveeTsE/p81Efsdr8Ozxp/UDeP2X/kSr4aTqYJaEab+mVxg2WIWiAKnvTIFn8VcouOpG5N09GJmnNuDZEytwXana+HfV7hEHMvLYEsw8swU3KVX1vV75SMG/O3yAPz1YKmLZRL5BHAUjjoQp18SLVg8ZeOsvzGAKzhVmXBcb16tdrqHR7cFnnAKlyneuYNWOXjS+w1wfEpl1MvSNUmV/FClV9jNmC84SsEyqfLk2hgzore+f8j88ccOWHfjgswUh82w4i8Bc60alqtehL7E0Jwszv9+GWxcvw87bx+Ffi68osfQXSarE59PfUrB3r4Rbb1bRob0X8smjSBt1NySvF+efnYnTFSqjzZ5ZyIeGZbXvQE1P6ZCDPKbloMPeOcj3avh+1Sm0/vpzfF+qF871egRXX+XupaoNmQpO75B0mRFSY/YSG9fXvqTom94b36GhaseSfPylSmxwXz62MD/WZU9oyKjibp5m+SV6eUqV/RGiVNnPmC04S8BSqRoxbjqGDuqjv/nnn/DMbPp9ZxGFb92IVIl9VC12v6svr+385xyU9ZTC+10/xIrVnhJLf0akasMGCXPmKqhSWcNfBxX+oU75MBMp8z9EQfuuyOv/NIYeW4z3zvysb1YXm9ZDXeNPrMQrp9ajW0plfDzuFWgaMLbq+/jTwHJFG+cTmX+ovollN3HWn1im6zymAIo150zjyBoZ28S5hCE2rvtL1aHFMnZ8KqN8Ey9ampwpc2MM3NZnSpX9EaNU2c+YLThLwDKp8s9T1bhBLQwcPhX+s1ZTMudg2oTHUaFcGWdHbHHrRqTKt3m8fbYX8195D3nX3Y7ndj6iL/39+aEC1AzI8B1u+U90X9WAKVMVnM2W0O8+FfXreSFln0H6qL6Qcs4j5+nXsaVKRf3omjKSB+vq3YXUIJuAsr35uGzP+8j2FuDjrbno9smHWJbxe3xeYxiGD3X3UtWBhTJ2zZNRqbWGZvdYO0O083MZB78PvnG9SKryNKycqCD3hISWD6oo39T8TJnFjy6rCyBAqbL/kUgGqYomT1UgUd+KzuXtmsecjNP+KLEFMwQskyrRCf90Cr40+8n+EBmRqr8fX4o3T2/G4JXb8fQ3S7Ht3kxkft006NKfkZkqcc/CRTLmL5DRsoWGPncUSoPny3eR+t+ZUFt0QO6jE3DboXlYlnMYkypdgb5lmpV4Tl46tQ4TT6xCG08FLJj0OqT8PEys8g5qdaiFXre6W6rWvuRB9n7oQiXEytIrzMZ1n1TtXw1sfUdGemUN7Yda3L6lg2FlPgKUKvufBbdLVbiM6kazhkebld3+qLAFKwlYKlVWdswtdRmRqm77P8a2/FP4fNbXuCIvDXM6zMSKVXLRG3yBY400UyXuF7NcE6coEElBfekVhBSlj+wL6cxJ5DwxFZ9UL42BRxbqR9aIo2v8rxxvgf7G3zEtF+/slnDz7P9gR6Wr8Wrqs7ijl4pLW7t3ZiX3mISVkxTIqUCXMQWGj5iJ5pkrtnG9i4ZGtxWKk0+qlr8k4cwuCY3/qKJqJ/eyjIaJ2++lVNkfQbdLVTBx8j/3zv/MvnA0rTj6xf5osYVYCMRVqsQS4bS3P8EDfW5MmmXASFJ1VMtB2z2zkapp2D9lNrRbHsJz6+4KufRndKZK3PfRJwrWrpP0DeW/+/X4Fc/C/yJ19svQ6jbF2eEvo+PeOTii5WBu9RvROb1a0TMiZs7EDFoDpQxWvPgfyOfOYmrVGdivNMBTw1Skp7tXBPZ+LWPvN7K+Od3ON+6CbVwXUnV4ZwGWTS5cHhRZ3JnsM5Z/muJfhlJlP3M3S1W4o9gEOaMzVeJeK46fsT9abCEWApSqWKj5lYkkVXPObsPjR39E9x0H8cFHC7Bl0Ad446OKIZf+opGqYOkVoKnI+Pv9kI4dQu6A0Zhc/xJMObkGPUvXx2tVuuk9L/BquHzfB8hSz+PVrDTcNXMGztTrgGfynkftml487PJN1fpepuOSnkZBpFOw8/LfuN72ERV1mqdgWaaGw2uhJ/oUCT95uYMApcr+OEUjVbmngdMH7f3+BhtxelkJZWqU/CSSCEUjVZEEzf5IsAW7CFCqTJKNJFV/ObIIH2fvwNj5KzDgXBl80HAiVqwMvfQXjVSJe1+foWDfPgl/6Kmi/WWF/wB5ln2L1LfGQ6tWG3tH/Qsd932g/35F3TtRRU7H+2e3YfDRH1FbKYXVr86F5+QxLLpqCv67oz26ddVwbTf3isDZfRLWvazos0SdnlZhOKW8iedg539lHPxRRkoZL674i4JF4wv5dR6tQikV/z8KJoZyURelVNkf/mikavdPGpa/Gf+9nXWvkHH5g4VJg/2vSIcjRyNVol6zBxXbHy22EAsBSlUs1PzKRJKqFnvexWktHz+++Tka3jwQYxddry/9DXhIRa2awf/gGtlT5evCuvUSPvy4eHoF8Vnac/2hHNiFvHuG4OEmGfg0eyceL98OQ8q308/4E2f9TTpRBv1ffw1a3SaYVDYTR49J6P+Aijp1ohOB3V9JOLxCRpV2XtS/2Vkh2/W5jAPfy6hxlYYGt8SvL76cWOIMa5GfqprfPiuTjxiLx4kApcp+0NFIVdYmL7Z8EX+pqtZSRvObZEqV/Y9DUrZAqTIZ1nBStTHvOK4/8F9Uyc7B1unzsPkvH2HGexlhl/5Ed7a8qeD0XglN+2oo3yS8GARLryDqUDYuQ9orI6GVr4wfn34Btxz+P32W6tnKnTHw8EJUktOwLfNzSMcP48R9z2Ls/65GWroXTw1VIUnGoYiUASsnXPivunaDVZSqFp2UGW8t8p0i2Wb+aQlt/6KidJRyGLn20Hf4b1wXd7UfqiK9snMczIzlYi1LqbI/8tFIlf29ia4FK5f/OFMVHXs33U2pMhmtcFKVeXoDnj2+An027MDLx8vgo0pPYvlKGVddoeGG3wWXpfxsCct/Pa+ubH0vWg+M/F9qCxbK+HahjFYtNdz5xwv1pk1+DMqOjcj740Bc01zBpvwTyJA8OO8twOhzFfHYyy9Dq1IL398yE5/N85QobwTNjk9kHPrpwn/VlW3oResBkftspO5o7xHZ08WMUVolLzoMi38fsvdLWP+qggpNvWh2X/zbj5YX7y9O70XOqgAAIABJREFUgFJl/xPhZqmKtA8q1PKfeNMvME9jJEGzPxJswS4CSSlVvtxY6zfv0LnNfHG4fnROqMs/v5a457lh/dCrR1f9dv/XZcXPN13XpdhxO+Gk6k9Z/8PC8wfw2ueLcWv3gRj7WUd96U9sBBcbwoNdJ7dK2DTjwsxPqwEqyjUMP+Phn15h6GAVl5QuvF/e8zPSxz8Cb+lLMGPkP/DEqeX670tLHmya9T3K7t6B3AeG4z+7fofNW+Ri+7KMPHBidmbZM4V9vXSQqguFuJr2VVG5TfxnaX75SEHWMknfHC42iTtxnd+SAilDQ3o9SpUT/M20SakyQ89YWTdLlRhhpJQKPgr+f3P8Txfxfc6UCsaeFzfelXRS5fuviS4dWupiJIRp5PjpGDuiv358TuAVeGZh4M/iS1SnZlVdynx1V69asSgbbjiparTzbeRIXmx55zscvfttvPWOJ+LS3/6FCnbPk5BWFhBvv5RrrKFV/8iC8NHHCtaul0oce5OWOQbKmh9x5uZ70OZSD05qeXg8rzL+PvWf8FasirPPvINxk1ORnw88+YSK0lFsrN71hYQDixT9DDxxFt7e/0nYO1/RN2x3eFKF2F8Uz2vpmMJz9pxcegs8UDme42db5ghQqszxM1La7VIVbeJO8Tdj8rTZ6Nure9Hfn2jrMMKV9yQOAcukKtyD4jtcefhf78bM9+fZmqcq8JzBQMkKRB8oXZHuF5K1ZOWmotmqUFL1Y84h9D70FVocOYlF+8tibtpDWLZcxpVdNPw+zCzKz+8qOLpOQpt7ZGz6SIWYDRKzQGXqhZ/5CZpeQcxWZe1F+jMPwpuShjXPTsPxtBR0fH0yym1ei7y7/obt9XpixtsKqlUFHvlzgeEnU8jLsn8UHi7c/onC/UPif4t0BnmnJNTsqqH+TZFl0HCDEW48sVnG5pkyStcC2j5qfBxWte+rh1JlNdH41Uepsp+126VKEIrmmJrANwaT/YQR+5+gxG8hLlIVzwOVg61fB5t+9Q+N+Hzet0uROWmI/uvJr87G+Kf6B01QGlhXKKkad3w5/nV6IwYt24xR1z6GCW/XRna2hP4PqqhTK7QgrX5exvkjMrqOkrFndQF2fSGjfDMvWvaLvJz0+psK9u2XcNstKi5rd6GN1HemwLP4K+Rf2wtq5+sKlwQvKYec8bPw9aI0LPoh/D6vYI/xnv/J2DdfRuW2XjT904W+ndwqY9OMwgOHL3tMQ0bV+IjVz+8pOLpW0kVOCJ1TF6XKKfLm26VUmWcYqYZkkKpIY+TnFzeBuEhV4OyOnch9s2LPDO2HjPRUvalIUqWL2Gvv4+iJ0ziYdazYnir/vgYTNnFMTLCrw6qZWI3z+PCH7Wh90/OY/HIBKlYAJo4OvSam5gGfPJIPSQF6vZYC8fO8J/ORdxa47mkPytcN/1re0pUa3nhHSJuEvw/1FHXLe/woTg/8g/6z0rwN1C3rkHH3IKT2/BOee74Ae/Z5MXiQBy2aGnvtryAX+HxIPtRc4HfPeFC2ZvFyi18pwMG1XlRqLKHbkxf6YVfcRQqDTx/Nh1YA3DwlRV86deoSb06Geiac6hPbNUaAsTPGycxd0bxZbKYdliUBpwiYlqrATd7BBlKjWiV9FijYniarBx7tTFXgLJpverZ3z25Fm9VFH0W9I8ZPLzGOg8fPlxjCaS0PzXe/B4+qYde+Cph3/nYsXSbjyis03Bhm6e/MHgnrXlFQtg5w9XAZJ7PzsP87Gbu+lFGxpYYW90dOr/D8CwrOZkt46AEV9epeML6UDzPh+eZDva/etAzkTpqNs2ppTJisICUFGDm8AErJ1CxBw7PvWxm7v5JRsZWGFveV7FPeSQkrJhYuDTYTm9bb2rtp/chqCT/PUiDePLz0z5Fn9Kx+5vzrq3BJKs7nFiAn37nZMjvHl8x116iYgWDf52Qec7zHJhjzIoFkJmBaqnxwEmXzXbR7qozMbIUSKjH2YMt/nx7fjEGnl+KqPVmY034QJmaWL1z666eiTu3QgiFSE4gUBbW6AG3vkXHybJ4+W7VirAI1R4KRHFDfLZQh/q9VKy/uvP2CYEjZZwoPW849j/wb+yL/lvux5v/v3Zr7iYKmTTTcfZcxCRCzQivGKfper7aPqigdYilTnL0nzuCLx6b1TW8pOLlFQsPbVFTvYq/ARfrHgMt/kQgl7udc/rM/Nlz+s58xW3CWgGVS5ewwLrQe6e0/38za+BH99Tf6An8OnKkKNvPlP9ZgUjV042y8VzoHT/18HDc3H4I3ZyooXdqLJ4eEn0X55SMZWctkNP+jFw2vUXSpEte+b2Ts+VpGpdYamt0TXn7ELNXzUxV9Cco/vYKoRzmwGzh7ElqdJvBmlMKHcxWs2yDhpt9r6Hy5Mak68IOMXZ/J+pl64my9UJeYpVo1WYFIDlrrtxrq9TBWf7TPkXpOwlKR10sGOo9y/lgYSlW0EUyc+ylV9seCUmU/Y7bgLIGkkyqBM1yeqkCJEvcH5qLyz1Ml9mO9OWtesSj5L2cGk6rLN76O/aVT8eWpWth/6Ab8tFTGFV3CL/2JBsTS39m9Ejo+6kXVZhekSsxWLX/OA+3/77kyMlvlk6WuV2vofk1wmRHSNU5IT46Evz2iolKlyDM83v+/Z2nFBAX5ZyS0elhFuUbhy5zaLmPj9MJN6x2eUJFWMXIb0X4dDi2VsWOujAotIi+PRlt3LPdTqmKhlhhlKFX2x4FSZT9jtuAsgaSUqngiDZSqXw5vR9dzP6Bcbh42NuyHSS+lFS79RTpTzwssHukBVODayV6kl7ogVWI8od62CzbWvfslTH9TQUaGF8MGq1BKng2K/QckZL6hoGwZL5543Ng+pENLJOz4WEGZul5c+oixMlvelnF8k2w431a0sfOdudf0LhWV/d54jLYeq+6nVFlFMv71UKrsZ06psp8xW3CWgKVSJWZ1Dh0+rudwEtfoyTPwxfwliOdG9XjjDJSqfy+eiRE1gZ5H8/BUtQF44y1jS3/nsoA1L3j0fE+/GQWkphSXKpEXavk4RT+sV09uGWFm6dVMBYeyJPS6VUW7IBvFF3wv49vvZFzeScPNNxpYmvMW5qASy3kt+qmo0MzYrJPYtL5y0q+b1u/WUOlSA20ZDGL+WQnLn1P0tyW7PFsAyf4XDSP2jFIVEVHC3kCpsj80lCr7GbMFZwlYJlWBmcj9N4Bv2LIDH3y2oNjxLs4O27rWA6XqoQWT8GX9qpik1kXF7d0Ll/46a7jxhvAycWSNhG2zFFRqo+GyflIJqRI93v2ljP0LZFRp70WTO8PPFIns6iLLevVqXgwKchbfGzMV7NkjoW8fDc2aRhadI6skbHtfQemaXrT9m7FZKh/lvfNl7P2f9ZvWDyyS9TxeVdp50eSu6Ppk3RNQvCZKlV1k7a+XUhUfxva3whZIwDkClkrViHHTMXRQHz11gn9uqHgm/4w3Sn+p0ratQzMsw7kUDxbXuh2zXyp860+kN6hbJ/zMjpADIQl1b9DQ9MbgUiXeuFs+tnDWRxwDk1YhdJ2qBkyZeiG9gn/7efnAuImF0zpPPVmA1EjHyXgLN53nHJP0jfJiw3xUl8i0/uum9drXaKj7+yjLh2hs7UseZO8HWjygokJzYzNnUfU7hpspVTFAS5AilCr7A8GZKvsZswVnCVgmVf4neDduUAsDh0/FkAG99TfsIr1B5ywCc637S9XqT1/CzW3LolYe8FGpBzB9RuHSn9jXFCnp3cY3FJzaJumCUKutHHSmSvR05+cyDn4vo2onLxr/MfzszLcLZSxYKKN1Ky96+6VX2LhZxvsfyGhQ34sH7o08w3NsvYyt/5H1JUex9AhjOUKLgbV603ruscJlRSXDi8v/rkIymGPLXLQjl6ZURWaUqHdQquyPDKXKfsZswVkClkmVGIZ/ItAH7+qhHzqc7Gcd+aRKys/DPz96GhO7tMA9KbXx203X46efZHS5XEMPAzMzS0cX5qLqOLIA5asoIaVKzFaJM/ckL9B+WPjZKl96BREbsRn9ktKFszmffq5g5SoJ13fX8JsrI88arX5BwfksCU36qKhyWewzQlvfkXFsgzWb1kWKCZFqoloXDY1uizyGeH3NKFXxIm19O5Qq65kG1kipsp8xW3CWgKVS5exQnGndJ1WeFQtwS85yLK1dBa9XuQZb3miIU6ckPHh/8czmwXqZe0rCynEKlHQvOj+jolRaaKnSZ6s+lXFwsTGh8KVX+O3VGq77Nb2CyGN1+oyEQQMKUL1aeG4ntkjY/JaiLzWKJcdYZql8LYhN66ueL9xs3/xeTc/IHuulb5o/LqH1AFXPpJ4oF6UqUSIRfT8oVdEzi7YEpSpaYrzfbQQoVSYj5pOqgsy/o1H3+lAVGV+n9MWsNzMML/0d3yxhy0wF5Zt40fKhyFIl8kQtH1+YJ6HTCFXPWh7q2rtP0pch9fQKQ1QcOwa8Ms2DUhleDBdLeRGu9f9SII7PadRLRbXO5uVl33cy9nwlI7VcoaSJN/eivc7uk7DuZUWvo+MIc6IXbduR7qdURSKUuJ9TquyPDaXKfsZswVkClkqVb1+VfxqFmtUq66kVunRoWewsPWeHbV3rQqqks6fw3fTH0fe2rmjnqYBHN9+GH3+S9SzlIlt5pMv3dpwv83ikmSpRn0h4KRJf1rhKQ4NbwrfhS69w+x80ZGcDX30t47J2Xtx2S3ipOrVDwsZMRZc2IS+xCFCJsftvWr9OQ90wZyGG4ubbV2ZnpvZIMQv1OaUqVnLOl6NU2R8DSpX9jNmCswQslSrxxl/9OtVx47VdMHnabPTt1V1/EzDY+XrODtu61oVUeebPxciTy/FGh2Z4tFwbeP7dSV/663efivr1Is/uiE3gYjN40z4qKl/mjbj8J3ov8kWtEvmfJODyUSo8pUK3s3adjI8+kfX0CmJf1fYdMu78o4pWLcP3beN0Bae2S6jfU0PN30SWQ6NUfZvWhaS1jzbTuldkl1eQny2h7d8KULqm0Vbjcx+lKj6c7WiFUmUH1eJ1UqrsZ8wWnCVgmVT5H6gsZqf8pSrZUyqkjxuIzjc0x/ZK5TDNcyNWzKiFSy4pfOvPyCXkSKQruGyIioyqxqRK1Lv9QwWHl0uoebWG+jeHl56JzyvIPnfhtb2nhqlITw8tVdn7Jax9SdFlreNTKuRIaReMDNTvnq3vyji2LvpN66d+kbDxdUU/8kbf45VgF6UqwQISRXcoVVHAivFWSlWM4FjMNQTiIlXJPFN1aMNWHJv6V7QedBtSIWPa9nuxeLEHnTtpuMlApnKxaXvJKI9+Pt6VYwv0jeBGlv98s1Viw7aY8RGzVSK9QKhr/gIZCxcV5h2oXcuLhx8MLySbZ8o4sVnWc0qJ3FJWX2JfmOi7vmn9Pg0VWxpr45ePFGQtk1Dneg11rjNWxuq+h6uPUhVP2ta2Ramylmew2ihV9jNmC84SsEyqxDDmzluEJSs3YcSjffHyjI/15b+K5cvoOat69+yWlHuqjkx/CbOzVuLRG7vg2ozaaD/7BpwQS3/3q6hfN/LS3+mdEja8pqBMHS8u/Uuh6BiVKnHvttkKjqyWdPEJl1Tz7FkJk14o3BV+bTcvunUNLVUifYJIoyDeRuw4UoWSas9Dun+hjN3zoti0rgJLn1MgjuwRs2dio3qiXZSqRIuI8f5QqoyzivVOSlWs5FjOLQQslSoxaDErdf9jE4qNf+aLw/UkoMl4He9/K/r/tgXmtqiHx5VOOP1WW/2tvyeHGFuaEqkRRIqE6p01NOxVOPMSjVSJZUOR7Vwsz3V6Kvxs1aq1Mk6e8KJdG6BixdBCsvU9BcfWSqgd40Zyw3FWgdVTZZw/IqNOdw11fhd+5knMnIkZtEvqetHG4IHOhvti0Y2UKotAOlANpcp+6JQq+xmzBWcJWC5Vzg4n/q2fuPNqNHjsDpxKTcFze27DrgWVjB9S7LcvquFtGqp3iV6qxIiLJKi7hroRxCQSoZyjhbmkjCwpRqrLyOdndktY/2phex2GqUgtH1r2fn5PwdG1kv62o3jrMREvSlUiRsVYnyhVxjiZuYtSZYYey7qBgGVS5b9RXbzx538l856qhX/tiW7390BlOR33ftxXf+tPHP0ijoAxcvnOr7v0ERVlfl0ujGamSrRxLkvCGouW67Z/oODwCgk1u2qof1N8xMUnhRVaaGhxf/A2vQXAkr974NWATqNUpFxijK+RGFh5D6XKSprxrYtSZT9vSpX9jNmCswTiIlXJ/Pbf6Fcfx7Odm6KH3Ag1Zl6jJ9kc/kTks/70sHuBxSM9gAp0+UdB0Rt20UqVqGrLv2Uc3yib2sAtNo+vGGcsTYOVj63/pvWW/TSUb1ZSrI6skbBt1oUEqVa2b2VdlCoraca3LkqV/bwpVfYzZgvOEoiLVPk2sD8ztB8y0m3a9ewQx6s3foIfcg7i4cNdoX7VFJ06aOhpcIYn+yCw9kUP0iv/elDxr2OIRar8Z6vETE4sKRB2fCLj0E8yql+hoeEf4jNL5QvbgUUydn0RetP6prcUnNwioUlvFVU6JOYslRgLpcqhL6IFzVKqLIAYoQpKlf2M2YKzBExLlf8hyqGGUqNaJWROGqInAk22K33l68iFigH/9ycUZJXC/feqaGhw6e/wSgnb5yio1NaLZn+6sLE9FqkSXDe/JePEFhn1emgQ2cajufwPahZv1oU7+iaaeo3eK5b11rxQuGld7Aur3f1C/9VzEpY+qwAy0HlMgW1vIxrta7j7KFVWUHSmDkqV/dwpVfYzZgvOEjAtVb7uh9tT5ewQ7W1dWjkNjaQK6Pb27dEt/YmDkT+XcfD7krmgYpWq7AMS1v4ztoSdYpZIzBZV7ehF4zuMvbloNdlQm9bFcTziWJ5Kl2podnd0smh1HyPVR6mKRChxP6dU2R8bSpX9jNmCswQskyojwxBnA057+xM80OdGVChXxkiRhL9HSNUNp1qh9qdXoGMHDbcYXPoTAxPn6onz9Vr2U1G+2YUlrVilStS56Q0FJ7dJeoZ1kWndyCXyPi37hwKvWnhsjFiOdOr6eZaCo2skPRmoSAoqrg2ZCk7vkNDsHg2VWhsbk1P9p1Q5Rd58u5Qq8wwj1UCpikSIn7udAKXKZASFVN2+7HqU31IX992jolED40KydLQCNUdC5zHF80uZkSrfbI9+CPJwFZIn8gD3fC1j3zdyiWXIyCWtv0NsWl81SYaaJ6FVfw2lqnv1s/7kVKDLmAI983wiX5SqRI5O+L5RquyPHaXKfsZswVkClCqT/G9a/X+o8p+uKJOi6Ak/5cKTYCJe4kDklRMUpJQRKQIKit1vRqpERb4ZsIa3aqh+ZfiZHTUPWDG2UO4uG6wio5pxKYw4yBhvOPiDjJ2fyUir4EX1zsDuryRU7aih8R2JPUslhkupijHoCVCMUmV/EChV9jNmC84SoFSZ5P/OR7n6mXqd2mvoGeFQY/+mjm+SseVtGeWbamj5YHFZMCtVp3+RseH1wjfpxKbzcNeBBQp2fSkhXI4ok4hiKi6OyRHH5fguMWtVrjGlKiaYLGSIAKXKECZTN1GqTOFjYRcQoFSZDNKI53Jx5KiM++/R0LCB8T/6e7+WsfcbGbW6aagXcPCyWakSQ1r3LwVn90ho1EtFtc7BZ5/EYcYiL5V486/toypK13J+lsoXDt8ypvg5pbQXnZ5W9cOmE/3iTFWiRyh0/yhV9seOUmU/Y7bgLIGLUqr8zye8tEVDTJvweNiN8y9kzsGbs+bpkQq8/6G/5etv/UWz9Cfq2fxvGSc2ymjWV0WlNsVlxgqpOrlNxqY3CpfQOgwPPlvlO3ewXBMNrR4yLoTxemS3zZFxaruEGlcBtX7rzBuJ0Y6VUhUtscS5n1JlfywoVfYzZgvOErjopErk1Ro5fjrGjuiv582KlJg08PPAn4VUdWyv4ZYolv5EyMV+KrGv6rInVGRUsV6qRBsivYJIsyBSJIhUCf6XeNNvxXgFYmN4qwEqyjVMnFkqZ78S5lqnVJnj52RpSpX99ClV9jNmC84SuOikSkjRrr2HMHhAb518oGQFhkPMUonLd7+Y5ZqSOadodktI1X13q2gUhZSIFAZLxyh61nNxPE3gZcVMlajzxCYJm99WkFbJiw5Diy+fZS2V8MtcRT9vUJw7yMsaApQqazg6UQulyn7qlCr7GbMFZwlcdFIVKEkiaenA4VMxZEBvdGrXvEQ0fBnje1zbWRcrUb5+nero1aOrfu/n83PRvl10S2ciN5V4Q++Sul60CSI0VkmV6N/qKTLOH5bR5C4VVdr9OhvlBVZOLJwpa/GAigrNOUtl1deQUmUVyfjXQ6mynzmlyn7GbMFZAnGVKmeHWth6oBRFkiqRsHT05Bk4dSYbPyxbX2JPVYEanVDps2PfeLH+Aw31fyuh3Z9K5mCQJAmSBGiaedk5sNqLZa9pKFUFuP45Rd/svXepFytnaChTA7huTIInfkqEhyaKPiiyBBE2r9d87KJolrdaQMCjyIjl+2xB0xdNFYIxLxJIZgKWSpVPUNZv3lGCmZEN4fEAHe1MVaCEieXDOZ8tKFr+O3wyN+pub50lI2sl0OR2L2pcUfKPb0aqjBSPgtPn8qOuu0QBL7B8soTzhyW0uEdDlTbA8okSzh+V0PJeLyoHbJI33+DFXUO50inIyS1AbgGlym1PQtXyaYjl++y2cTrZX8GYFwkkMwFLpSpQWBIRXDR7qnyzVHf07Fa0NBi4B+vAsfNRD3Ptix5kHwQu/YuKMnVK/vG1cvlPdO7YOglb31WQUVVDvRuALe/ISK/kRfth3EsVdfAiFODyn9VE41cfl//sZ83lP/sZswVnCVgmVW45UDnS23+BM1FCFA8dPo5nhvZDRnqq/rag/0xVLFK1+MnCs2PEJnWxWT3wslqqRP2rn5dx/ogMJcMLsVG+6Z0aKrePfunS2cc18VunVCV+jEL1kFJlf+woVfYzZgvOErjopErgDpenKlCafLNVX8xfokcqcBkzWqnK3g+sfcmDjKpeXDYk+EyRHVJ1eJWE7e8X7p/Sc1c96Y5kms5+PaJvnVIVPbNEKUGpsj8SlCr7GbMFZwlYJlViGIH7j5wdWnxaj1aqDq+Qsf0DGZXbaWh6V/CZIjukStBYOUlB7jEJjW/XUPVyzlLZ8YRQquygGp86KVX2c6ZU2c+YLThLwFKpEktr7879BkMH9tGXyi6GK1qp2vmpDJHJvF4PDbV+G1+puhji4fQYKVVORyD29ilVsbMzWpJSZZQU73MrAcukKtybfwJOorz9Z3WgopWqDa8pOL1TQsuHVJRvEvwNMbtmqqweO+srSYBS5d6nglJlf+woVfYzZgvOErBMqpwdhnOtRytVS0Z5IA4y7jxG1TeNB7soVc7F02zLlCqzBJ0rT6mynz2lyn7GbMFZApQqk/yjkaqcoxJWTVaQWsaLjqNCpzOgVJkMioPFKVUOwjfZNKXKJEADxSlVBiDxFlcToFSZDF80UnVsvYyt/5H1Y2HE8TChLkqVyaA4WJxS5SB8k01TqkwCNFCcUmUAEm9xNQFLpcp3Tt7BrGMloHBPFbDnfzL2zZdR+xoNdX8f+u07SpV7v1OUKvfGjlJlf+woVfYzZgvOErBMqnz5nLp0aIm2rRoXewtQpFq4unOboAcWOzt8861HM1O1+S0ZJ7bIaNpXDXs8DKXKfFycqoFS5RR58+1SqswzjFQDpSoSIX7udgKWSZV/RnUBZfKrszH+qf6oUK6Mnmzzg88WFGUldzs0//5HI1UrxirIOy3hsqEqMiqHPhuOUuXeJ4RS5d7YUarsjx2lyn7GbMFZArZIVcXyZTD+pXcx4tG+ulSJZUF/yXJ2yNa2blSqxNEwS8co+rE04niacBelytoYxbM2SlU8aVvbFqXKWp7BaqNU2c+YLThLwDKp8l/+69Wja7Hs6uLolyUrN13UM1WntknY+IaCMvW9uHRg+IOMKVXOfinMtE6pMkPP2bKUKvv5U6rsZ8wWnCVgmVQFDsM/GWiNapWQOWkIGtWr6exobWjd6EzVgUUydn0ho/oVGhr+IfwRMZQqGwIVpyopVXECbUMzlCoboAZUSamynzFbcJaAbVLl7LDi17pRqfp5loKjayQ0ul1FtctD76cSPadUxS9+VrdEqbKaaPzqo1TZz5pSZT9jtuAsAUqVSf5GpWr1FAXnD0to81cVl9SmVJnEnrDFKVUJG5qIHaNURURk+gZKlWmErCDBCVgqVb59VV/MXwLfkl/NapUxevIMiFQLYq9Vsl2GpEoFFo/06EO/cmwBoISnwJkq9z4llCr3xo5SZX/sKFX2M2YLzhKwVKpEPqr6darjxmu7YPK02ejbq7u+j+piT6lwdq+Eda8oKFUNaDc4/Jt/XP5z9gthtnVKlVmCzpWnVNnPnlJlP2O24CwBy6TKP0+VmJ3yl6qLPaXCoSUSdnysoMplXjTpE/7NP0qVs18Is61TqswSdK48pcp+9pQq+xmzBWcJxEWqLvaZql8+lpG1REb9Hhpq/jb8m3+UKme/EGZbp1SZJehceUqV/ewpVfYzZgvOErBMqsQwfPmoRNLPl2d8rC//iUSgA4dPRe+e3S7aPVXr/qXg7B4JrfqrKNc4/CZ1SpWzXwizrVOqzBJ0rjylyn72lCr7GbMFZwlYKlViKGJW6v7HJhQb1cwXhyfluX9ikEY2qi8Z5YGWD3Qeo0LJoFQ5+8jb2zqlyl6+dtZOqbKTbmHdlCr7GbMFZwlYLlXODif+rUeSqvNHJKx+XkFqOS86PhV5PxVnquIfQytbpFRZSTO+dVGq7OdNqbKfMVtwlgClyiT/SFJ1dK2En99TUKG5hhYPRN5PRakyGRCHi1OqHA6AieYpVSbgGSxKqTIIire5lgClymToIknV7i9l7F8go/Z1GupeT6kyiTvhi1OqEj5EITtIqbI/dpQq+xmzBWcJWCpks4dwAAAYGklEQVRVInXCgGFTcDDrWIlRXdqiIaZNeBwVypVxdsQWtx5JqjbNUHByq4Rm92io1JpSZTH+hKuOUpVwITHcIUqVYVQx30ipihkdC7qEgGVS5cumnqyZ00PFM5JULX9OQf5ZCe2HqUivFHmTOpf/XPLNCdFNSpV740epsj92lCr7GbMFZwlYJlX+yT9FFnUnL9EXkcZh/eYdejfCvX0Yanbtpuu64Jmh/ZCRngqRKf7NWfP0ugJn3MJJVd5pYMVYD+QUoMs/ImdS9zHjMTVOPj3m2qZUmePnZGlKlf30KVX2M2YLzhKwTKp8M1V39OzmaPqEwBkzIU0jx0/H2BH99SNzjFy+43bEWYW+3Fs+wQr8OZxUndgqYfMMBWUbeNH6z8be/ONMlZEIJe49lKrEjU2knlGqIhEy/zmlyjxD1pDYBCyTKjHMQOFwYuiBR+JEuywZWF4IlrgGD+it/3+Rh2tK5pyi/WHhpGrfdzL2fCWjxpUaGtxqbD8VpcqJp8a6NilV1rGMd02UKvuJU6rsZ8wWnCVgqVQlwkb1QOkReAPFKBxy/1kqcZ9vTD2u7ayLVeDn4aRq67sKjq2T0PiPKqp2MrafilLl7BfCbOuUKrMEnStPqbKfPaXKfsZswVkClklVtDNCdg072DmDRqUq2MHPvnGdOpONH5atL7GnKjc/9LLet2M0ZGcBXUdIKFdXMjxkWZYgSxIKVOOzW4Yr5422EkhRZKiaF5rXuETb2iFWbphAWoqCcN9nwxXxxpAEBGNeJJDMBCyTqkTZqB7rTFUoKQycmRJLnHM+W1C0/HfsdF7Q50McS7PwSQmQgG6TvJCi+LckPUWGxyPj7Hnjm9uT+SF109jKlPIgN09FXgGlyk1xE32tVDYVob7PbhtLovZXMOZFAslMwDKpSpSN6rHuqQomY8HGFLjxPdTy35ndEta/qqB0DaDtY9HJEd/+c+9Xjst/7o0dl//sjx2X/+xnzBacJWCZVIlhJMJG9Uhv//n2SI0f0b/oLcVwS5dipurQ4eNF6RUCZ6pCSdWhn2Ts+ERGlfZeNLnT+Jt/giOlytkvhZnWKVVm6DlbllJlP39Klf2M2YKzBCyTqsDcUIHDimdG9XB5qoJJVTgZ9AnXF/OX6EMymqfql48UZC2TUP9mDTWvjm5vFKXK2S+FmdYpVWboOVuWUmU/f0qV/YzZgrMELJMqZ4fhXOuhZqrWvazg7D4JrR5WUa5RdPtrKFXOxdNsy5QqswSdK0+psp89pcp+xmzBWQKUKpP8g0qVF1g80gOoQOcxKpQMSpVJzK4pTqlyTahKdJRSZX/sKFX2M2YLzhKgVJnkH0yqzmUBa17wILW8Fx1HRLefSnSHM1Umg+JgcUqVg/BNNk2pMgnQQHFKlQFIvMXVBChVJsMXTKqOrJawbbaCCi00tLg/uv1UlCqTAXG4OKXK4QCYaJ5SZQKewaKUKoOgeJtrCVCqTIYumFTt+kLGgUUy6nTXUOd3lCqTiF1VnFLlqnAV6yylyv7YUarsZ8wWnCVAqTLJP5hUbZyu4NR2Cc3v1VCxFaXKJGJXFadUuSpclKo4h4tSFWfgbC7uBChVJpEHk6qloxWoORI6PKkirWJ0m9S5/GcyIA4Xp1Q5HAATzXOmygQ8g0UpVQZB8TbXEqBUmQxdoFTlnpKwcpwCOQXo8o/oMqn7usKN6iaD4mBxSpWD8E02TakyCdBAcUqVAUi8xdUEKFUmwxcoVSc2Sdj8toKyDb1oPSD6N/84U2UyIA4Xp1Q5HAATzVOqTMAzWJRSZRAUb3MtAUqVydAFStW++TL2/E9Gjd9oaNAz+v1UlCqTAXG4OKXK4QCYaJ5SZQKewaKUKoOgeJtrCVCqTIYuUKq2viPj2AYZje9QUbVj9PupKFUmA+JwcUqVwwEw0TylygQ8g0UpVQZB8TbXEqBUmQxdoFStmqgg57iEto8WoHSt2CrnnqrYuCVCKUpVIkQhtj5QqmLjFk0pSlU0tHivGwlQqkxGzV+qtHxgySgPoABXji0ApNgqp1TFxi0RSlGqEiEKsfWBUhUbt2hKUaqiocV73UiAUmUyav5SdXqHhA2ZCkrVBNr9LbY3/0R3KFUmg+JgcUqVg/BNNk2pMgnQQHFKlQFIvMXVBChVJsPnL1UHf5Sx878yqnTwoknv2N78o1SZDIjDxSlVDgfARPOUKhPwDBalVBkExdtcS4BSZTJ0/lK1/QMFh1dIqN9TQ83fxPbmH6XKZEAcLk6pcjgAJpqnVJmAZ7AopcogKN7mWgKUKpOh85eqtS95kL0faPWwinKNYnvzj1JlMiAOF6dUORwAE81TqkzAM1iUUmUQFG9zLQFKlcnQFUmVF1g80gOohZnURUb1WC/uqYqVnPPlKFXOxyDWHlCqYiVnvBylyjgr3ulOApQqk3HzSVX2QWDtix6kVfCiw/DY91NxpspkQBwuTqlyOAAmmqdUmYBnsCilyiAo3uZaApQqk6HzSdWRlRK2zVFQsZWG5vfGvp+KUmUyIA4Xp1Q5HAATzVOqTMAzWJRSZRAUb3MtAUqVydD5pGrXZzIO/CCjzu801OlOqTKJ1bXFKVWuDR0oVfbHjlJlP2O24CwBSpVJ/j6p2pip4NQOCc3v01CxJaXKJFbXFqdUuTZ0lKo4hI5SFQfIbMJRApQqk/h9UrV0tAI1R9L3U4l9VWYublQ3Q8/ZspQqZ/mbaZ0zVWboGStLqTLGiXe5lwClymTshFTlHpewcqICJd2Lzs+Y26QuukOpMhkUB4tTqhyEb7JpSpVJgAaKU6oMQOItriZAqTIZPiFVxzfK2PJvGeUaetFqAKXKJFJXF6dUuTd8lCr7Y0epsp8xW3CWQFJK1YlTZzBw+FSs37xDpzvzxeHo1K55UNK/7D6AAcOm4GDWsWKf33RdFzwztB8y0lNxPicPoyfPwBfzl+j3PDesH3r16Kr/byFVe7+WsfcbGTWu1tDgZnP7qThT5ewXwmzrlCqzBJ0rT6mynz2lyn7GbMFZAkknVT4B6tKhpS4+QppGjp+OsSP6o1G9moZov5A5B/XrVNfLB9YXWIGQqi1vyzi+SUbj3iqqdjC3n4pSZShECXsTpSphQxOxY5SqiIhM30CpMo2QFSQ4gaSTKiFRk1+djfFP9UeFcmUiSlFgfALLz523CLv2HsLgAb2DhlJI1YrxCvJOSmj7WAFK1zAfce6pMs/QqRooVU6RN98upco8w0g1UKoiEeLnbieQdFK1fM0WTMmcg2kTHtelSlxi5klcocTIP4j+s1S+sm/Omld0S41qlZA5aUjRrNfefTlYOkYBFODKsQWAZP6RoFSZZ+hUDZQqp8ibb5dSZZ5hpBooVZEI8XO3E0hKqfrgswVF+6GikapQs1x39OxWtCdLzFzN+WxBkbTtXV+Apf/0omwdCb8Zbs3j4JElyLKMvALzm96t6RFrMUogzaOgQNWges0vAxttk/dZQ6BUmgfncgusqYy1BCUgGPMigWQmkJRSFctMVbC9U77f+UuVbxP8kAG9ddFa90U+fv4YqNkFaHmXNY9KqkeGR5H5D7w1OONaS+l0D/LyVeSrlKq4gregsfKlU3AyO9+CmlhFKAKCMS8SSGYCSSdVse6pCrZs6Jvl8m1aFz8LqRoxbjqGDuqjLwEufDUPR1ZJaHCLhhpXmX/zT7TB5T/3fuW4/Ofe2HH5z/7YcfnPfsZswVkCSSdVkd7+86VQGD+if9GSXrg3/IRsjRg/vWgflVj+W7JyU9Hy4rxR+Th3CGg9QEXZhtbMTlCqnP1SmGmdUmWGnrNlKVX286dU2c+YLThLIOmkyjebFCpPVTCpChSlwJCIz5+eNEP/9aUtGhbbBP/hQ4XLBZ2fK4CSak0wKVXWcHSiFkqVE9StaZNSZQ3HcLVQquxnzBacJZCUUhVPpEKq0it50X6YdZvKKVXxjKC1bVGqrOUZz9ooVfbTplTZz5gtOEuAUmWSv5CqSq01NLvHmv1UojuUKpNBcbA4pcpB+CabplSZBGigOKXKACTe4moClCqT4RNSVfd6DbWvo1SZRJkUxSlV7g0jpcr+2FGq7GfMFpwlQKkyyV9IVYv7VFRoac0mdc5UmQyIw8UpVQ4HwETzlCoT8AwWpVQZBMXbXEuAUmUydEKqOj6lIrUcpcokyqQoTqlybxgpVfbHjlJlP2O24CwBSpVJ/ju25yC9gnVCxZkqkwFxuDilyuEAmGieUmUCnsGilCqDoHibawlQqkyGThyobPXFjepWE41ffZSq+LG2uiVKldVES9ZHqbKfMVtwlgClyiR/SpVJgElWnFLl3oBSquyPHaXKfsZswVkClCqT/ClVJgEmWXFKlXsDSqmyP3aUKvsZswVnCVCqTPKnVJkEmGTFKVXuDSilyv7YUarsZ8wWnCVAqTLJn1JlEmCSFadUuTeglCr7Y0epsp8xW3CWAKXKJH9KlUmASVacUuXegFKq7I8dpcp+xmzBWQKUKpP8KVUmASZZcUqVewNKqbI/dpQq+xmzBWcJUKpM8qdUmQSYZMUpVe4NKKXK/thRquxnzBacJUCpMsmfUmUSYJIVp1S5N6CUKvtjR6mynzFbcJYApcokf0qVSYBJVpxS5d6AUqrsjx2lyn7GbMFZApQqZ/mzdRIgARIgARIggSQhQKlKkkByGCRAAiRAAiRAAs4SoFQ5y5+tkwAJkAAJkAAJJAkBSlWSBJLDIAESIAESIAEScJYApcpZ/sVa/2X3AQwYNgUHs44V/f7SFg0xbcLjqFCuTAL1lF3xERAxm/zqbIx/qn+xGJ04dQYDh0/F+s079Ftnvjgcndo1J7gEIvBC5hzUr1MdvXp0LepVYNzEBzWqVULmpCFoVK9mAvWeXSEBEkhEApSqBIqK+AM9cvx0jB3Rn/+AJ1BcgnXF/49voPiez8nD6Mkz0KVDS/0PNuOaWMGcO28Rnp40Q+/Uc8P6BZWqIQN6U4ITK2zsDQm4ggClKoHCxD++CRQMg10JNlMV+LtAyTJYNW+zmUC4mSpKlc3wWT0JJCkBSlUCBTZw+Y9LfwkUnBBdCSZVy9dswZTMOcWWbcUfcHENHtA78Qd1kfTQyPIfl/4ukoeBwyQBiwhQqiwCaUc14h/9Q4eP45mh/ZCRnmpHE6zTJIFQUvXBZwuKxY1SZRK0DcWDSVVgM2KpcM5nC7iv0Qb+rJIEkpEApSqBoxpqE3QCd/mi6xpnqtwbciNSJfbOjRg3HUMH9eE+R/eGmj0ngbgRoFTFDXX0DVGqomcW7xLcUxVv4ta1R6myjiVrIgESKCRAqUqgJ+H/FixD4wa1i/6LmEtGCRScEF0JJlV8+y/x4yZ6GEyqxH44cfnSX4jlvyUrN3EJ3h0hZS9JwHEClCrHQ3ChA+If9Psfm1D0i5uu68J/zBMoPv5dCZbP6MG7ehRtRGeeqgQNHAD/lAqil/6b0fmySOLGjT0jATcQoFS5IUrsIwmQAAmQAAmQQMIToFQlfIjYQRIgARIgARIgATcQoFS5IUrsIwmQAAmQAAmQQMIToFQlfIjYQRIgARIgARIgATcQoFS5IUrsIwmQAAmQAAmQQMIToFQlfIjYQRIgARIgARIgATcQoFS5IUrsIwmQAAmQAAmQQMIToFQlfIjYQRIgARIgARIgATcQoFS5IUrsIwmQAAmQAAmQQMIToFQlfIjYQRIgARIgARIgATcQoFS5IUrsIwmQAAmQAAmQQMIToFQlfIjYQRIgARIgARIgATcQoFS5IUrsIwmQAAmQAAmQQMIToFQlfIjYQRIgARIgARIgATcQoFS5IUrsIwmQAAmQAAmQQMIToFQlfIjYQRIgARIgARIgATcQoFS5IUrsIwm4iMD5nDyMnjwDXTq0RK8eXYP2/MSpMxg4fCqGDOiNTu2au2h07CoJkAAJhCZAqeLTQQIkEJbA8jVbMGL8dGROGoJG9WpGpEWpioiIN5AACSQpAUpVkgaWwyIBpwhQqpwiz3ZJgAScJkCpcjoCbN8UAd8y0qD7bsXnX/+EL+Yv0et7bli/oqUn3z3rN+8oauvBu3pg8IDe+s/B6rjpui547OE7MHjMvxCqnE8e2rRshHWbfilqW9T9QJ8b9eUtX1n//hgZsJgdmpI5R18eE7NEB7OO6cVmvjg8quWyufMWYcnKTbj5d1fo/RFXjWqVSsw6ifuenjSjqGv+7fj6Mm3C46hQrox+zy+7D2DAsClF/RK/E8yeGdpP/9y3/Ldr7yG8OWue/jvf5xnpqUXMH7jz93jr/a9Ccgpsxz9u/vLma+fSFg0h+nn85Jli/Qs2ZiNx4D0kQAIkEA0BSlU0tHhvwhHwCdHR46eKRMH3h3j8iP66gIh73pr9JQbe9wf4/0Hv3bObLl7B6vDJVrhyvj/qqzZsK9G2KO9bLhP9GTl+OsaO6G9o+UyUFSJz/2MTiomIEJ85ny3QpcEnN5EC4pMlfxl5IXMODh0+rguQ4OETL9/PgfwCpSrwc9EH/zp8UiUE1ydnPsaBzMW9vvEE1hv4s4939aoVdSH2/ezfjr8k++/XEmPYe+BwyD1ekTjycxIgARIwQoBSZYQS70lYAqE2PAtxEJdvNipwAEICxOyG+DyaTdP+5YItcxn9XSSgoWaHopWzQGHyCZuYBRMyI64R46Zj6KA+xYTPn19gX4KxDSZVgRvV/csZiVukvqenpQXdEB+LxEaKBz8nARIgASMEKFVGKPGehCUQ6o9zqNkX3zKaGJBvOSonNzfkm2hGl7l8b7m5TaoCl8n8A+2b3fKXqlAiY5VU+dcz7e1PUL9O9WKzSyLePgmsWa1yUKnyn8ES44l26TVhH3Z2jARIIOEJUKoSPkTsYDgCRqTqy2+X6PuF/PcJ+f/xDiVVvqWzUOVEvwJTB7hRqiLNfgWTqjt6diu2tyuRpMr3vFCu+G8HCZBAvAlQquJNnO1ZSsDIMpJYdgqc8TAiVZHKJYNUiTFEyhcVz5kq/yXCWJf/gj1gkZaDLX0oWRkJkMBFS4BSddGGPjkGHkyqAvMqBW7M9i3ptW/dRN+sHWqmKlK5ZJAqseFdjHPet0uLvRHov7E7cE9V4IZ5Xwzq1qxa4u0//+SfkfZUBcbN6Eb1wL1bop7vl64r2k9nJMVDcnwbOAoSIAGnCVCqnI4A2zdFIFi6hMDX5wOXgcReKl8ahHBSFalcskiVGEdgSgV/hsE2zfvfL9IYXHvVZdi+c3/UUuWfriJY2gOjKRX85S1SCg1TDxwLkwAJkEAYApQqPh6uJhDNm3uuHmiCd97/rcgE7yq7RwIkQAK2EaBU2YaWFceDgNukKnBGKBgjI2+riaU0X1LNUJyjTRRqNF5i9mj+9yvx8N099SJui4HRcfI+EiABEoiWAKUqWmK8P6EI8A96/MMRLM2EXQIX/9GxRRIgARKInQClKnZ2LEkCJEACJEACJEACRQQoVXwYSIAESIAESIAESMACApQqCyCyChIgARIgARIgARKgVPEZIAESIAESIAESIAELCFCqLIDIKkiABEiABEiABEiAUsVngARIgARIgARIgAQsIECpsgAiqyABEiABEiABEiABShWfARIgARIgARIgARKwgAClygKIrIIESIAESIAESIAEKFV8BkiABEiABEiABEjAAgKUKgsgsgoSIAESIAESIAESoFTxGSABEiABEiABEiABCwhQqiyAyCpIgARIgARIgARIgFLFZ4AESIAESIAESIAELCBAqbIAIqsgARIgARIgARIgAUoVnwESIAESIAESIAESsIAApcoCiKyCBEiABEiABEiABChVfAZIgARIgARIgARIwAIClCoLILIKEiABEiABEiABEqBU8RkgARIgARIgARIgAQsIUKosgMgqSIAESIAESIAESIBSxWeABEiABEiABEiABCwgQKmyACKrIAESIAESIAESIAFKFZ8BEiABEiABEiABErCAAKXKAoisggRIgARIgARIgAQoVXwGSIAESIAESIAESMACApQqCyCyChIgARIgARIgARKgVPEZIAESIAESIAESIAELCFCqLIDIKkiABEiABEiABEiAUsVngARIgARIgARIgAQsIECpsgAiqyABEiABEiABEiABShWfARIgARIgARIgARKwgAClygKIrIIESIAESIAESIAEKFV8BkiABEiABEiABEjAAgKUKgsgsgoSIAESIAESIAESoFTxGSABEiABEiABEiABCwhQqiyAyCpIgARIgARIgARI4P8BsPn6lw1xY2YAAAAASUVORK5CYII=",
-      "text/html": [
-       "<div>                            <div id=\"8e731f5c-5a0a-40b5-9a4a-6ed8b2dbef01\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"8e731f5c-5a0a-40b5-9a4a-6ed8b2dbef01\")) {                    Plotly.newPlot(                        \"8e731f5c-5a0a-40b5-9a4a-6ed8b2dbef01\",                        [{\"hovertemplate\":\"param_hybrid_weights=(1, 0, 0, 0, 0)\\u003cbr\\u003eparam_n_neighbors=%{x}\\u003cbr\\u003emean_test_score=%{y}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"legendgroup\":\"(1, 0, 0, 0, 0)\",\"line\":{\"color\":\"#636efa\",\"dash\":\"solid\"},\"marker\":{\"symbol\":\"circle\"},\"mode\":\"lines\",\"name\":\"(1, 0, 0, 0, 0)\",\"orientation\":\"v\",\"showlegend\":true,\"x\":[4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19],\"xaxis\":\"x\",\"y\":[0.8008378078301959,0.8400062445502972,0.8096721096361099,0.8559125351204843,0.8336324358130058,0.8527611277611278,0.8366577903898239,0.8614862699888679,0.8543397891689771,0.8646500028077732,0.8579139153827342,0.8649543378995436,0.8570850413953863,0.8684907085177009,0.8638235448485803,0.870748299319728],\"yaxis\":\"y\",\"type\":\"scatter\"},{\"hovertemplate\":\"param_hybrid_weights=(1, 1, 1, 1, 1)\\u003cbr\\u003eparam_n_neighbors=%{x}\\u003cbr\\u003emean_test_score=%{y}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"legendgroup\":\"(1, 1, 1, 1, 1)\",\"line\":{\"color\":\"#EF553B\",\"dash\":\"solid\"},\"marker\":{\"symbol\":\"circle\"},\"mode\":\"lines\",\"name\":\"(1, 1, 1, 1, 1)\",\"orientation\":\"v\",\"showlegend\":true,\"x\":[4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19],\"xaxis\":\"x\",\"y\":[0.8075935453622654,0.8430578785922963,0.8186283695823878,0.8460811690308093,0.8401247232523816,0.8613621686330353,0.8420278333481293,0.860641288478862,0.8498768836797005,0.8614241048332417,0.8543264207057311,0.867633122214403,0.8680721392635153,0.8692013791818098,0.8692013791818098,0.8692013791818098],\"yaxis\":\"y\",\"type\":\"scatter\"},{\"hovertemplate\":\"param_hybrid_weights=(3, 1, 1, 1, 1)\\u003cbr\\u003eparam_n_neighbors=%{x}\\u003cbr\\u003emean_test_score=%{y}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"legendgroup\":\"(3, 1, 1, 1, 1)\",\"line\":{\"color\":\"#00cc96\",\"dash\":\"solid\"},\"marker\":{\"symbol\":\"circle\"},\"mode\":\"lines\",\"name\":\"(3, 1, 1, 1, 1)\",\"orientation\":\"v\",\"showlegend\":true,\"x\":[4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19],\"xaxis\":\"x\",\"y\":[0.8042368616580481,0.8524093598806555,0.8216261310206399,0.848984918136226,0.8427930652715798,0.8622252963759347,0.854621049850091,0.8638022080190918,0.8519063391000493,0.86297102497116,0.8578221153148611,0.8657296456608151,0.8653682852451325,0.867633122214403,0.8688259281038822,0.8692013791818098],\"yaxis\":\"y\",\"type\":\"scatter\"},{\"hovertemplate\":\"param_hybrid_weights=(1,)\\u003cbr\\u003eparam_n_neighbors=%{x}\\u003cbr\\u003emean_test_score=%{y}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"legendgroup\":\"(1,)\",\"line\":{\"color\":\"#ab63fa\",\"dash\":\"solid\"},\"marker\":{\"symbol\":\"circle\"},\"mode\":\"lines\",\"name\":\"(1,)\",\"orientation\":\"v\",\"showlegend\":true,\"x\":[4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19],\"xaxis\":\"x\",\"y\":[0.7546531749844266,0.8236489483815183,0.7971094199066515,0.8240579332078364,0.802456834960865,0.8394657957400525,0.8231423720288751,0.8521637096606087,0.8431410284217963,0.861854780372371,0.8534741237538748,0.860362294426858,0.8563573621610562,0.8654881749426915,0.8587845852444392,0.8677751535191309],\"yaxis\":\"y\",\"type\":\"scatter\"}],                        {\"template\":{\"data\":{\"histogram2dcontour\":[{\"type\":\"histogram2dcontour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"choropleth\":[{\"type\":\"choropleth\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"histogram2d\":[{\"type\":\"histogram2d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmap\":[{\"type\":\"heatmap\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmapgl\":[{\"type\":\"heatmapgl\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"contourcarpet\":[{\"type\":\"contourcarpet\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"contour\":[{\"type\":\"contour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"surface\":[{\"type\":\"surface\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"mesh3d\":[{\"type\":\"mesh3d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"parcoords\":[{\"type\":\"parcoords\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolargl\":[{\"type\":\"scatterpolargl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"scattergeo\":[{\"type\":\"scattergeo\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolar\":[{\"type\":\"scatterpolar\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"scattergl\":[{\"type\":\"scattergl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatter3d\":[{\"type\":\"scatter3d\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattermapbox\":[{\"type\":\"scattermapbox\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterternary\":[{\"type\":\"scatterternary\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattercarpet\":[{\"type\":\"scattercarpet\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}]},\"layout\":{\"autotypenumbers\":\"strict\",\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"hovermode\":\"closest\",\"hoverlabel\":{\"align\":\"left\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"bgcolor\":\"#E5ECF6\",\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"ternary\":{\"bgcolor\":\"#E5ECF6\",\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]]},\"xaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"yaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"geo\":{\"bgcolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"subunitcolor\":\"white\",\"showland\":true,\"showlakes\":true,\"lakecolor\":\"white\"},\"title\":{\"x\":0.05},\"mapbox\":{\"style\":\"light\"}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"param_n_neighbors\"}},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"mean_test_score\"}},\"legend\":{\"title\":{\"text\":\"param_hybrid_weights\"},\"tracegroupgap\":0},\"margin\":{\"t\":60}},                        {\"responsive\": true}                    ).then(function(){\n",
-       "                            \n",
-       "var gd = document.getElementById('8e731f5c-5a0a-40b5-9a4a-6ed8b2dbef01');\n",
-       "var x = new MutationObserver(function (mutations, observer) {{\n",
-       "        var display = window.getComputedStyle(gd).display;\n",
-       "        if (!display || display === 'none') {{\n",
-       "            console.log([gd, 'removed!']);\n",
-       "            Plotly.purge(gd);\n",
-       "            observer.disconnect();\n",
-       "        }}\n",
-       "}});\n",
-       "\n",
-       "// Listen for the removal of the full notebook cells\n",
-       "var notebookContainer = gd.closest('#notebook-container');\n",
-       "if (notebookContainer) {{\n",
-       "    x.observe(notebookContainer, {childList: true});\n",
-       "}}\n",
-       "\n",
-       "// Listen for the clearing of the current output cell\n",
-       "var outputEl = gd.closest('.output');\n",
-       "if (outputEl) {{\n",
-       "    x.observe(outputEl, {childList: true});\n",
-       "}}\n",
-       "\n",
-       "                        })                };                });            </script>        </div>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.3s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.1s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.3s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=7, slices=[slice(0, None, None)]; total time=   1.0s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   1.1s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=16, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=12, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=12, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.6s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=12, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.1s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.6s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=16, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=16, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=5, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=10, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.6s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.6s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=5, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=10, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=16, slices=[slice(0, None, None)]; total time=   1.0s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.6s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=12, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.6s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.3s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=5, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.6s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=10, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=16, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=5, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.6s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.6s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=16, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.3s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.3s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   1.1s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.1s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=1, slices=[slice(0, None, None)]; total time=   1.0s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   1.0s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.6s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.3s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.6s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=10, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=10, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=10, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=16, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.3s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=5, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=8, slices=[slice(0, None, None)]; total time=   1.0s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   1.0s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.6s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.6s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=16, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.3s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=6, slices=[slice(0, None, None)]; total time=   1.0s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=12, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=12, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.3s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.1s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=12, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.9s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.6s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=5, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=10, slices=[slice(0, None, None)]; total time=   0.6s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.2s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=12, slices=[slice(0, None, None)]; total time=   0.8s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.1s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=10, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=16, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.7s\n",
-      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.7s\n"
-     ]
+     "data": {
+      "text/plain": [
+       "array([[0.49277155, 0.30522343, 0.51419298, 0.48658798, 0.5571723 ,\n",
+       "        0.42588411, 0.5239025 , 0.5611968 , 0.50391897, 0.61166363,\n",
+       "        0.43768643, 0.51528197, 0.68236618, 0.63598903, 0.52674253,\n",
+       "        0.45519885, 0.57564773, 0.5984484 , 0.40373024, 0.30511737,\n",
+       "        0.63870972, 0.50726512, 0.30408372, 0.68612973, 0.37461595,\n",
+       "        0.5468843 , 0.40992071, 0.30231952, 0.37225154, 0.52394841,\n",
+       "        0.49238869, 0.43564842, 0.61429304, 0.4612128 , 0.49802845,\n",
+       "        0.453821  , 0.50071817, 0.58059138, 0.41075284, 0.62730237,\n",
+       "        0.36509254, 0.45475719, 0.52427778, 0.63430034, 0.33792695,\n",
+       "        0.48620817, 0.42914794, 0.56057509, 0.69621025, 0.40077768]])"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "import plotly.express as px\n",
-    "pdf = pd.DataFrame(best.cv_results_)\n",
-    "fig_df = pdf.copy()\n",
-    "rm_idx = []\n",
-    "rm_idx += list(fig_df[fig_df['param_n_neighbors'] <= 3].index)\n",
-    "rm_idx += list(fig_df[fig_df['param_metric'] == 'euclidean'].index)\n",
-    "\n",
-    "fig_df = fig_df.drop(list(rm_idx))\n",
-    "fig = px.line(fig_df, x=\"param_n_neighbors\", y=\"mean_test_score\", color='param_hybrid_weights')\n",
-    "fig.show()"
+    "scikit_model.predict(query_X)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "eeaeae77-1e0e-489e-843d-37624319cade",
+   "execution_count": 18,
+   "id": "31b0c034-9d62-474f-89a0-54aa768498bd",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.11/site-packages/sklearn/metrics/pairwise.py:2182: DataConversionWarning: Data was converted to boolean for metric jaccard\n",
+      "  warnings.warn(msg, DataConversionWarning)\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "index 1 is out of bounds for axis 0 with size 1",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[18], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# this will error out\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m \u001b[43mgenra_model\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpredict\u001b[49m\u001b[43m(\u001b[49m\u001b[43mquery_X\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/usr/local/lib/python3.11/site-packages/genra/rax/skl/reg.py:150\u001b[0m, in \u001b[0;36mGenRAPredValue.predict\u001b[0;34m(self, X)\u001b[0m\n\u001b[1;32m    147\u001b[0m y_pred \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39mempty((X\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m0\u001b[39m], _y\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m1\u001b[39m]), dtype\u001b[38;5;241m=\u001b[39mnp\u001b[38;5;241m.\u001b[39mfloat64)\n\u001b[1;32m    149\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m j \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mrange\u001b[39m(_y\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m1\u001b[39m]):\n\u001b[0;32m--> 150\u001b[0m     denom\u001b[38;5;241m=\u001b[39mnp\u001b[38;5;241m.\u001b[39msum(\u001b[43mneigh_sim\u001b[49m\u001b[43m[\u001b[49m\u001b[43mj\u001b[49m\u001b[43m]\u001b[49m)\n\u001b[1;32m    151\u001b[0m     num \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39msum(_y[neigh_ind, j] \u001b[38;5;241m*\u001b[39m neigh_sim[j], axis\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m)\n\u001b[1;32m    152\u001b[0m     y_pred[:, j] \u001b[38;5;241m=\u001b[39m num \u001b[38;5;241m/\u001b[39m denom\n",
+      "\u001b[0;31mIndexError\u001b[0m: index 1 is out of bounds for axis 0 with size 1"
+     ]
+    }
+   ],
+   "source": [
+    "# this will error out\n",
+    "genra_model.predict(query_X)"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/misc/example_j_index_error.ipynb
+++ b/notebooks/misc/example_j_index_error.ipynb
@@ -1,0 +1,1893 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "86ceb649-529a-4f4b-a3c2-4e98c7888608",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "1211-170013:db_connection.py:80 mongodb://user:pword@ccte-mongodb-dev.epa.gov:27017/genra?serverSelectionTimeoutMS=5000&authSource=admin\n",
+      "1211-170013:db_connection.py:226 Connect '' OK: URI connector\n",
+      "1211-170013:db_connection.py:80 mongodb://user:pword@ccte-mongodb-dev.epa.gov:27017/genra?serverSelectionTimeoutMS=5000&authSource=admin\n",
+      "1211-170014:genra_celery.py:31 Using Celery broker: redis://redis:6379/0\n"
+     ]
+    }
+   ],
+   "source": [
+    "def warn(*args, **kwargs):\n",
+    "    pass\n",
+    "import warnings\n",
+    "warnings.warn = warn\n",
+    "from IPython.core.debugger import set_trace\n",
+    "import json\n",
+    "from genraweb.resources import DB\n",
+    "from genraweb.lib.fp.genfputils import FPGen\n",
+    "import pandas as pd\n",
+    "from genraweb.lib.chem_id import ChemID\n",
+    "from genra.rax.skl.cls import GenRAPredClass\n",
+    "from genra.rax.skl.reg import GenRAPredValue\n",
+    "from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor\n",
+    "\n",
+    "from genra.rax.skl.reg import GenRAPredValue\n",
+    "from sklearn.metrics import make_scorer,explained_variance_score,roc_auc_score,r2_score,f1_score,accuracy_score,precision_score,recall_score\n",
+    "from sklearn.model_selection import GridSearchCV\n",
+    "from sklearn.model_selection import LeaveOneOut\n",
+    "import time\n",
+    "import seaborn as sns\n",
+    "import pylab as pl\n",
+    "import os\n",
+    "\n",
+    "import itertools\n",
+    "\n",
+    "\n",
+    "from genraweb.lib.new_genrapy import GenRAPredClassHybrid, GenRAPredValueHybrid, GenRAPredBinaryHybrid\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d186373d-d22f-43e0-939c-220141c7ae2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = pd.read_csv(\"/genra/gridsearch_data.csv\").set_index(\"dsstox_sid\")\n",
+    "with open(\"/genra/gridsearch_slices.json\", \"r\") as f:\n",
+    "    slices = json.load(f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "418e54fb-de51-4860-b9f4-9fc67a95f404",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(432, 5740)\n",
+      "(415, 5740)\n",
+      "(432,)\n",
+      "(415,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "y = 'CHR:liver__tox_txrf_binary'\n",
+    "df = data[data[y].notnull()]\n",
+    "fp_slices = [slice(elem[\"start\"],elem[\"end\"]) for elem in slices[:5]]\n",
+    "cols_list = list(df.columns)\n",
+    "cols = []\n",
+    "[cols.extend(cols_list[_slice]) for _slice in fp_slices]\n",
+    "\n",
+    "X_sample = df[cols]\n",
+    "is_na = X_sample.isna().sum(axis=1)\n",
+    "print(X_sample.shape)\n",
+    "X_sample = X_sample.drop(is_na[is_na>0].index)\n",
+    "print(X_sample.shape)\n",
+    "Y_sample = df[y]\n",
+    "print(Y_sample.shape)\n",
+    "Y_sample = Y_sample.reindex(index=X_sample.index)\n",
+    "print(Y_sample.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "550d8c52-00a4-4309-9513-5aafe97335c0",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 5 folds for each of 152 candidates, totalling 760 fits\n",
+      "12.75064754486084\n"
+     ]
+    }
+   ],
+   "source": [
+    "hybrid_binary = GenRAPredBinaryHybrid(\n",
+    "    algorithm='brute',\n",
+    "    metric='jaccard',\n",
+    ")\n",
+    "params = [\n",
+    "    {\n",
+    "        \"n_neighbors\": range(1, 20),\n",
+    "        \"metric\": [\"euclidean\", \"jaccard\"],\n",
+    "        \"hybrid_weights\": [\n",
+    "            (1, 0, 0, 0, 0),\n",
+    "            (1, 1, 1, 1, 1),\n",
+    "            (3, 1, 1, 1, 1),\n",
+    "        ],\n",
+    "        \"slices\": [fp_slices]\n",
+    "    },\n",
+    "    {\n",
+    "        \"n_neighbors\": range(1, 20),\n",
+    "        \"metric\": [\"euclidean\", \"jaccard\"],\n",
+    "        \"hybrid_weights\": [(1,)],\n",
+    "        \"slices\": [[slice(0,None)]]\n",
+    "    }\n",
+    "]\n",
+    "grid = GridSearchCV(\n",
+    "    estimator=hybrid_binary,\n",
+    "    param_grid=params,\n",
+    "    n_jobs=30,\n",
+    "    cv=5,\n",
+    "    verbose=1,\n",
+    "    scoring=make_scorer(f1_score),\n",
+    ")\n",
+    "os.environ['PYTHONWARNINGS']='ignore'\n",
+    "start_time = time.time()\n",
+    "best = grid.fit(X_sample, Y_sample)\n",
+    "run_time_binary = time.time() - start_time\n",
+    "print(run_time_binary)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "94643969-d78f-45bd-ab87-c366fdece7d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.870748299319728"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "best.best_score_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "08b7fee3-b4b4-4782-883f-1d3df5860a40",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'hybrid_weights': (1, 0, 0, 0, 0),\n",
+       " 'metric': 'jaccard',\n",
+       " 'n_neighbors': 19,\n",
+       " 'slices': [slice(0, 2048, None),\n",
+       "  slice(2048, 3678, None),\n",
+       "  slice(3678, 4227, None),\n",
+       "  slice(4227, 4806, None),\n",
+       "  slice(4806, 5740, None)]}"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "best.best_params_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "e270b641-6f85-4032-8a31-1a44f89798f4",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "hovertemplate": "param_hybrid_weights=(1, 0, 0, 0, 0)<br>param_n_neighbors=%{x}<br>mean_test_score=%{y}<extra></extra>",
+         "legendgroup": "(1, 0, 0, 0, 0)",
+         "line": {
+          "color": "#636efa",
+          "dash": "solid"
+         },
+         "marker": {
+          "symbol": "circle"
+         },
+         "mode": "lines",
+         "name": "(1, 0, 0, 0, 0)",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19
+         ],
+         "xaxis": "x",
+         "y": [
+          0.8008378078301959,
+          0.8400062445502972,
+          0.8096721096361099,
+          0.8559125351204843,
+          0.8336324358130058,
+          0.8527611277611278,
+          0.8366577903898239,
+          0.8614862699888679,
+          0.8543397891689771,
+          0.8646500028077732,
+          0.8579139153827342,
+          0.8649543378995436,
+          0.8570850413953863,
+          0.8684907085177009,
+          0.8638235448485803,
+          0.870748299319728
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hovertemplate": "param_hybrid_weights=(1, 1, 1, 1, 1)<br>param_n_neighbors=%{x}<br>mean_test_score=%{y}<extra></extra>",
+         "legendgroup": "(1, 1, 1, 1, 1)",
+         "line": {
+          "color": "#EF553B",
+          "dash": "solid"
+         },
+         "marker": {
+          "symbol": "circle"
+         },
+         "mode": "lines",
+         "name": "(1, 1, 1, 1, 1)",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19
+         ],
+         "xaxis": "x",
+         "y": [
+          0.8075935453622654,
+          0.8430578785922963,
+          0.8186283695823878,
+          0.8460811690308093,
+          0.8401247232523816,
+          0.8613621686330353,
+          0.8420278333481293,
+          0.860641288478862,
+          0.8498768836797005,
+          0.8614241048332417,
+          0.8543264207057311,
+          0.867633122214403,
+          0.8680721392635153,
+          0.8692013791818098,
+          0.8692013791818098,
+          0.8692013791818098
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hovertemplate": "param_hybrid_weights=(3, 1, 1, 1, 1)<br>param_n_neighbors=%{x}<br>mean_test_score=%{y}<extra></extra>",
+         "legendgroup": "(3, 1, 1, 1, 1)",
+         "line": {
+          "color": "#00cc96",
+          "dash": "solid"
+         },
+         "marker": {
+          "symbol": "circle"
+         },
+         "mode": "lines",
+         "name": "(3, 1, 1, 1, 1)",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19
+         ],
+         "xaxis": "x",
+         "y": [
+          0.8042368616580481,
+          0.8524093598806555,
+          0.8216261310206399,
+          0.848984918136226,
+          0.8427930652715798,
+          0.8622252963759347,
+          0.854621049850091,
+          0.8638022080190918,
+          0.8519063391000493,
+          0.86297102497116,
+          0.8578221153148611,
+          0.8657296456608151,
+          0.8653682852451325,
+          0.867633122214403,
+          0.8688259281038822,
+          0.8692013791818098
+         ],
+         "yaxis": "y"
+        },
+        {
+         "hovertemplate": "param_hybrid_weights=(1,)<br>param_n_neighbors=%{x}<br>mean_test_score=%{y}<extra></extra>",
+         "legendgroup": "(1,)",
+         "line": {
+          "color": "#ab63fa",
+          "dash": "solid"
+         },
+         "marker": {
+          "symbol": "circle"
+         },
+         "mode": "lines",
+         "name": "(1,)",
+         "orientation": "v",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19
+         ],
+         "xaxis": "x",
+         "y": [
+          0.7546531749844266,
+          0.8236489483815183,
+          0.7971094199066515,
+          0.8240579332078364,
+          0.802456834960865,
+          0.8394657957400525,
+          0.8231423720288751,
+          0.8521637096606087,
+          0.8431410284217963,
+          0.861854780372371,
+          0.8534741237538748,
+          0.860362294426858,
+          0.8563573621610562,
+          0.8654881749426915,
+          0.8587845852444392,
+          0.8677751535191309
+         ],
+         "yaxis": "y"
+        }
+       ],
+       "layout": {
+        "autosize": true,
+        "legend": {
+         "title": {
+          "text": "param_hybrid_weights"
+         },
+         "tracegroupgap": 0
+        },
+        "margin": {
+         "t": 60
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "xaxis": {
+         "anchor": "y",
+         "autorange": true,
+         "domain": [
+          0,
+          1
+         ],
+         "range": [
+          4,
+          19
+         ],
+         "title": {
+          "text": "param_n_neighbors"
+         },
+         "type": "linear"
+        },
+        "yaxis": {
+         "anchor": "x",
+         "autorange": true,
+         "domain": [
+          0,
+          1
+         ],
+         "range": [
+          0.7482034458546877,
+          0.8771980284494669
+         ],
+         "title": {
+          "text": "mean_test_score"
+         },
+         "type": "linear"
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlUAAAFoCAYAAAB+Cg5cAAAAAXNSR0IArs4c6QAAIABJREFUeF7snQd4FFXXx/8zsyUd0gOh94ACgkiRJkVAQBQFRdRXUQQLIhYU9PUVGyhYQAQVaVJEuoIU6SAd6b1DSAjpPVtnvu/Osslm2WTbbCDx3OfhCdm9bX73Lvvn3HPP4SRJkkCFCBABIkAEiAARIAJEwCsCHIkqr/hRYyJABIgAESACRIAIyARIVNFGIAJEgAgQASJABIiAAgRIVCkAkbogAkSACBABIkAEiACJKtoDRIAIEAEiQASIABFQgACJKgUgUhdEgAgQASJABIgAESBRRXuACBABIkAEiAARIAIKECBRpQBE6oIIEAEiQASIABEgAiSqaA8QASJABIgAESACREABAiSqFIBIXRABIkAEiAARIAJEgEQV7QEiQASIABEgAkSACChAgESVAhCpCyJABIgAESACRIAIkKiiPUAEiAARIAJEgAgQAQUIkKhSACJ1QQSIABEgAkSACBABElW0B4gAESACRIAIEAEioAABElUKQKQuiAARIAJEgAgQASJAoor2ABEgAkSACBABIkAEFCBAokoBiNQFESACRIAIEAEiQARIVNEeIAJEgAgQASJABIiAAgRIVCkAkbogAkSACBABIkAEiACJKtoDRIAIEAEiQASIABFQgACJKgUgUhdEgAgQASJABIgAESBRRXuACBABIkAEiAARIAIKECBRpQBE6oIIEAEiQASIABEgAiSqaA8QASJABIgAESACREABAiSqFIBIXRABIkAEiAARIAJEgEQV7QEiQASIABEgAkSACChAgESVAhCpCyJABIgAESACRIAIkKiiPUAEiAARIAJEgAgQAQUIkKhSACJ1QQSIABEgAkSACBABElW0B4gAESACRIAIEAEioAABElUKQKQuiAARIAJEgAgQASJAoor2ABEgAkSACBABIkAEFCBAokoBiNQFESACRIAIEAEiQARIVNEeIAJEgAgQASJABIiAAgRIVCkAkbogAkSACBABIkAEiACJKtoDRIAIEAEiQASIABFQgACJKgUgUhdEgAgQASJABIgAESBRRXuACBABIkAEiAARIAIKECBRpQBE6oIIEAEiQASIABEgAiSqaA8QASJABIgAESACREABAiSqFIBIXRABIkAEiAARIAJEgEQV7QEiQASIABEgAkSACChAgESVAhCpCyJABIgAESACRIAIkKiiPUAEiAARIAJEgAgQAQUIkKhSACJ1QQSIABEgAkSACBABElW0B4gAESACRIAIEAEioAABElUKQKQuiAARIAJEgAgQASJAoor2ABEgAkSACBABIkAEFCBAokoBiNQFESACRIAIEAEiQARIVNEeIAJEgAgQASJABIiAAgRIVCkAkbogAkSACBABIkAEiACJKtoDRIAIEAEiQASIABFQgACJKgUgUhdEgAgQASJABIgAESBRRXuACBABIkAEiAARIAIKECBRpQBE6oIIEAEiQASIABEgAiSqaA8QASJABIgAESACREABAiSqFIBIXRABIkAEiAARIAJEgEQV7QEiQASIABEgAkSACChAgESVAhCpCyJABIgAESACRIAIkKjycg8kphV42cOtzQO0AjRqAZm5BsX7pg59SyAsWIN8nQk6o+jbgah3xQlUDfeHLz7Pik+0HHfIGFMhAhWZAIkqL1fXF/8Ik6jyclFuY3MSVbcRvpdDk6jyEqALzUlUuQCJqpRrAiSqvFw+ElVeAqxgzUlUld8FJVHl+7UjUeV7xjTC7SVAospL/iSqvARYwZqTqCq/C0qiyvdrR6LK94xphNtLgESVl/xJVHkJsII1J1FVfheURJXv145Ele8Z0wi3lwCJKi/5k6jyEmAFa06iqvwuKIkq368diSrfM6YRbi8BElVe8idR5SXACtacRFX5XVASVb5fOxJVvmdMI9xeAiSqvORPospLgBWsOYmq8rugJKp8v3b/ZlG1//BpfPXjYkyfMAqhlYI9gq1EHyUNXKAz4H8TZ6FNy8bo/1BHj+ZX1o3uxDmTqPJyF5Co8hJgBWtOoqr8LiiJKt+vHYmq2yeqlq/ZjsWrtpYo6u4EgcJE45jxM/Djl2+hbs2qTjekK3POyMrBy+99g7eGDUSr5o2c9ultBRJVXhIkUeUlwArWnERV+V1QElW+XzsSVbdPVDlbXVcEirM+yvp9V+ZMoqqsV8XL8UhUeQmwgjUnUVV+F5RElW/WzmwG9u3ncekK8PYrWqeDWL8EX/lPP6zesBt/btojt/lk9JDCY6kLVxIxbPRXuH4jrbA/2/cd9dG7axu88dIAvPnR9zh26mJhuxcGPYQ3hw2Uf7d+STdtXBdHT14oHJvVef7JXrLFw9rWdjynDwXAenTHLCbMGmOd+5xv35MtKCV9+dse+Z2/lCAfIT7/RE+8+dE0edgq0eHFLDvMIrXnn5Po072tPF9W2Bjxicny6+PeGQJ/P438Oqv73y9nFZu+q89lZRUTFVbIz/540tEz2Y9pfX42CUfHm47Wmq0lew5WrEeWl+OTMPPXNfJr9u9b9xB77+64OrK1zk+rldvavufqs5e23mSpcuXTUEodElVeAqxgzUlUld8FJVGl7NpJEnDsOI+NWzhkZnJy5z9PVjsdxPpFnJqeVSgWrF+s48cMlQUI+33Tjn/w0tN95f7s33fUB6vHXp+9aC1e/s8jsrCw1hvYt7Ms2KxC4eDxc7eMzdpbj6XYeO+Pn4HPxgx16ZjKKhiee2NC4Rc+G9/+SO7rHxcjKTm9UPjYCxcmOlgftkLQvg+raLGtYxVQtqLKvp0rVh/7xbMKOKtQY/NnwsYqlBinidMWYfzYobIfmX19+3WzF1X279s/h1VUMWFkL06ta1qSWGVzZcUqqO33htONWkIFElWekrvZjkSVlwArWHMSVeV3QcuLqOJys8DlZAH52eCYGegOKAUQYeQkGGH5c/WGhEMngPRcwCxIgFpCzdpmvP1MV6ezdfVL0L4j9iVZq3qMLI7cOfJhX/TMysG+XB0JC1dfc/ZgJVlhbMWZvViz/91RH/bPai9crPOyfV2n19/iZ+SJqLKdDxtn/JQFqFc7Frl5BTJP+zHHfD4D77zyZDEhaitu7J/PXviUJKrsnett2znaC548q7P1tb5PospVUiXUI1HlJcAK1pxEVfld0NshqriCfHB5WWBCCfm54LIywOVlQropnPi8bHC52UBuplyHy8tRBHByoB+SA/2R5q9FUlAAUgK1uBHoj5QALdh7eWo1jAIHoyDAcPOnkedh4HkYBR4GgUeexrnVyX6yUsuXnc6/JEFkLxasVhvbDq3WmdJElavHSdYbcGUpquwtU/aWK0eiyn5+roiqxBupt1jaPBEatpzZOuzYexT9erYvtE4xq6BV6Dribl0767rZPp/1eM5eMNk+n9VS5a6osooz69Gn9bjQeizqdJOWUoFElTf0AJ9ktaeEyl4uym1sTqLqNsL3cmhnoooz6gGDEfJPkwGcwQDJpAeMhlItRlxaMvgrp4EcJooyweVkA3nZ4LOK/IHcmbrkHwi9phKu54eCVwkICASCAoG0SmqkaAWka9RI8lchWcv+CEjxUyNVo0Kyn+VPmlblznAu1dWaRajMkvxHLUpQs5+SBD9I0EgSNKIEP7OEnT3fdtqfK6Jq+tyVWLN5bzFfImfWCdsvUls/Hmdf0mUpqqxzZLf0Ph8zFGPHzyh2a01JUWV7LMfG9URU2bZh1r4OrZvirkZ1MHH6IvR/qAN+WbweA/p2LjyydXZk6khUWds7srh5I6ps+1NSXJGocvoRL70CWaq8BFjBmpOoKp8LKpw7ioA1c2HMyweMenBGIyT5pwFcQZ7PHkpSayAFVQICQyAFV5L/LgVWAkIqQwoMAW6+hoBKkIJDcNQPWHEiEzsTM5AeloY8/3wU+BdAr9W7NcfKvAaRgh8ihABE8v6IEPwQrQpAhOCPGFUA/DkBGvBQcwLU7CfPyX8v9hrHQSxQY9sODrv38oXj168nokc3CVFRUuFrulQOacd4tHrc4iBdWnF2/Mf8oZiDsf2XrSuiyvaI0NUv6bIWVdbnZw7xVqdqa1wrpY7/lLJUWUUg89XKzs0vPNpjnHPzdUhMSi30p3LlSNYXlirr+tnvF/s9qFQMMBJVzj7hTt4nUeUlwArWnERV+VtQ4eJJaCa/C86gczp5SesPMCGk0co/oSr6u6TSAPLrakCtlf8uqdSAxg8IDIYUVBlSMBNLQbJwksKjSxzvujkPZ4yZOK5Px0l9Os4aM3HKmFHq/Pz0fvDP94O/zh9hnD9qhfijYZQfYv39EcMHIEzQIpKJJiHA6XM6q2A0Abv2CPj7b0BvsDihx8ZK6PWgiBrVi8QUez1pF4/La3iIRuDxn50fGTr68rWNX1Q1OkIWVfa3zmwduEsTZraO4NYjqRZ31b/lNtntOP6zcrc6fNvfRnP0xW9/ROjK8R875rL3V7I6uLt7A856DGt7hOboNfZsbEx7CyOry24mMt72z2fvTG9d1xpVo0pcL+s47Ketn5ztfmH9MP+vMa8PLgzEWhI3Z58F+/dJVLlLzK4+iSovAVaw5iSqyteCCpdPQ/PtaHD6Aqhbd0Jux8duCiY1pJvCiIkkSeu9ECmJzBFDKk4aMnBGn4HjxnQc16ciRzI5rB6cE4zI7DB0qRmKdmFhiFUFyRanKD4AV67wOHQEOHGKg+Gm0OE4oE5tEU3vBhrHSdBqigsed1dLFIFDh3ls2sohN9cipiIjJXTrIiGuoVisO0MWh/NLOGSes1ixotuI6PCi6yEVbMMe2IcNsLXmsL6ZT461sC/SkkSV1WphvUbPhIA1fIL9Ff3bKapKCoLpyI/M3h/IVVFlz2LMiMFyGAl3I6rb36Bk6+DoNev62IdUsF1bR6LRtj6z3HW5/x6w0BIlrZe9qGK/2/pzWa1/zN/LGoKB1bG3Crr72bDWJ1HlKbmb7UhUeQmwgjUnUVV+FpRPvATNpDfAF+TjWos2WPnsk9DrAS3Hw59TQcsJ8IMALS/Aj1PBj+OhlX+qoOV5y2sQEMw7t74wKvHmXJzSZ8gWpxP6NJwyZOCiKduxeOJUiNOE4S5NOGpJoTi3IQz8pQhEBgl4/lkRlStLYKJFU+lWkWQyASdP8zh8BLhwkQcLbcCKIAAN64to1hRoUF+Uf3ennDrNY8MmIDXNIpIqVZLQpbOE5k1FMPFmW1KPcLiwnIdZx0EVJKHBExIqNxDhSvBPV46J3Jl3eayrlNWkPD67sznb3tZ0Vvd2vE+iykvqJKq8BFjBmpOoKh8LygSV9us3weXlYnKfbpjQpAp0KG5pcfdJmBArEl6CRZRxAgSOx2lDBvJLsD7VVYWgvqYymmkj0EQThobqyqimCpKHT0nmMHcBj+wcDrFVJTw7WIS/v4Trf1uO1AKiJdTsKaGynZXIOndmTTpyjMfRo8D1G0XKh1ms4uKYILJYskor8fEc1m7gce2apX2Av4TOnSS0ue/WduYCDueWckg/bhFeYXeJqP+4BMHfouwqoqhyFEDTnqc7R2p3gqgs7aae9dmUvDFX0v6zj0d2J7Bx9u8CiSpnhJy8T6LKS4AVrDmJKsuCnjvP4+IlCZ06AH5+3h05Kb1F+KR4aCe9jv2h/hjZpwNOV/KXh6iUVQkRvD/CwwC+yO+6cHgjzNCJJujZT4n93Qy9ZCrxqM5+3iG8GnfJ1qcINNSEIo4JKU1EiY936TKPhYs42WcprpGIAf1FSAUczi7ikHW++ASDakio1UtESJ2SWScnczh4mMPhIxzyC4oEVlCQhKZ3Sbj7LkkWbtaSlsbhr40cTp2xjKVWAfe3M+P+dnB4jJh5lsfZ3ziYcjnwfhLq9pMQ2aK48KqIokrp/eksR5/S493J/TkSd7Y3N+/EuZOo8nJVSFR5CbCCNfeVqDpnzIKa41BLFXLHE9u6Q8DmLZYvbY1Gkr+E729jhsb5xS+fPxufkoC8Ke9g3L11MK9ZPcscDRq0OtgKjc7Gyb9rtRYfodat3LNcMUuURWwVCS89E14wo5YqGNFuOIgfOcpj2UqLmGHz6N1LRPoJXrYCmfNvipaHJYgm4OoGDsYcC+9K9UTU7CUhqFrpQvb8BYv/1clTPGzjh4aHSWjaFMjKlHDwcJFwY3Ng1qnAgFv7ZQ7ol1bxuHHzBmBIXVE+7nN0NOmKqPL5JqABiIAPCZCo8hIuiSovAVaw5r4QVbNyTuG/aXsRwfthcUxPNNRUviOp6fQclq/kcPqmZYPdBktIsHzZsyOrju2B+1qZZYvH7ShcWhKWrJqIj1o3QIa/xWG63sV6aL2/Dbq2VKPNPVr8ucmA06ctYiImWkK/PqJ8q60sy7YdAjbdFKU9uotoe6+Ii7/zSN5vmVdwbQmNBotQB1vmxU4Vk/bxiN9ksRKxEhonyseCATGlz93w/zfyjp+0+F9dvnyrea7p3SK6dpEQ6sB3i42Tc4XD2V956DM4cAJQq7eIKu1EwM7HysqPRFVZ7iQa63YQIFHlJXUSVV4CrGDNlRRVaaIOI5N3YIsuoZBSIKfCwioP4l5N1B1Fjjkvz1vAISOTk4+GbgzYg+N+CXicb4yAnXVx8aRFxAQGSujUUUKrFu47SnvzwOfSLuLds79jb5VQuZuwjBDcv68jesZEyaIhOFiS/X3Y5/ncBR6r/izKV9eyhSXukq+PMdnNuqUrBBw/wUHggcf7m1GrMnD6F4toARMtPUVU7eBYtDCL0fVdAhK2AqZ8i6oJv1tCzV4i/MKdC8OcHHY0yCxYEsLCgAe7Fo81VYy/Gbi8nkPidgGQgMCqEhoOFuEXUfo4JKq82cXUtjwQIFHl5SqRqPIS4G1q/mn6frxQqTGqCIGKzkApUbWlIAEjU7YjTbQEdXw/9F6cNKRhRd4l+cbZjOgH0MW/mqJz97SzM+d4LF7Kw2gEQqIMONBnE/YXJEOnNspdsvk+yNdB7OFGMBy2xGZiN8ce6CihWTNRFhC+KgWSCROv78SPhkvyEFqjGfceaYmHjS3QozsQGVF0xGcbUZ0dibGgljt2CvLxGHPOfvBBCfc4uOmmxNwNBmD+Il62FrHjx2efEsGd43F1/U1LX6SIhoMlBFRxLo7MBshiJ3EbYL4ZWiHiHhE1e0jQhjpv7+x5CpI4nF7Io+Cm43u1rmbUeNC1fklUOaNL75d3AhVSVNnHMHHm2GbvDGd/U8M+noft+ySqyt9HYGrWMYzP+Eee+Fuh9+DNSs0UewglRNX7aXswJ+e0PCfmizMjugv8E8IRGyvi4+w9mH3zve8jO+KRwDqKzd2TjjZu5rD9b8vd/Kp352Jpq/U4ZcrAy9s6oM216pj64Hbsj7xW2HUdqTIanItD5MH6si8TCw3QpZOE5s3c819yZa5/5l/G+9f3IEWwBPXsdToVTZOeQ78ukahZ41YR4ChNTUYWh1WrOTAfJFaqV5PQr6+IqEjXRIQr88zN4zB3Ho8byZxsMXu6H5D8J5B387ZdTFsRtfuI4Nw8NmU38eK3sOCbghx4k1m6oluJqNFNKjw6dGV+hXUkIHGbgMt/cYAZsvWr4SARgXbBPkvrk0SVW8SpcjkkUOFElX1KAfss3/ZrZH9F0/53Z/mQSFSVr11/1piFBxJWFJt0rCoQ48LuQ6+Aml4/jDei6rQxA8OSt+C80RK76PngRvhveCtIOhWmfZUHgyYYD3SWsKfBYXyZcVCu81l4GzwX3MjrebvbgU7HYfGyIrFRt2cKvo5Zj1RRh47XamPEqq6FXeqaZ2F+u71YL10tNkyza/VR/XhDRCfHyBajbg8AcXHei6tEUx7eSNiNnZJFzFXPysW4zZdRt9P/UK9FcImPWlruPxajac16DllZFssRCyfAjg29DaZpGzKB+XD1bSohcS0Hs56DKkBCg0GW+E7eFGMuh/iNHJJ2F5kEq9wvono3SR7DlaLL4HB2IY/cq5bn91TokahyhTbVKc8EKpyoYiLKNlGkM1FkL7ocZfxmiSJZlF5HhURV+dr+3RN+x0ljBt7beQxtriVj1BN9cAkFli9KbQwmRbZDbS9u2HkqqmbmnMSnaQdggCg7pH8f1Qnt/arI89qwmUOzla/jhroWllR6B6GVJZh6nsZkzU7mziJb2pjFrawKEwLzf+XBrDhaPwk1BlzFOH4L2FFbS2ME3p/5AMxSJQSZLyBXqCtPS+OnQ9hACcuqHsOi3PNIMucXTjcipzLqnYlD/fP1UDNUg25dJbD8ce4WkyTi66QTmFZwBEbeBK1JxKi9JzDsRCa0Y7+25NgrpQTp/ZCrLTlVDQuquXV7kWWOhSLo3VNEk8auCRP7oS9f4bCAOXkbODSoKaElJyHjhEX4sLhT9Z+QoA70rG9Hj2nI5HB1I1fo8M4sX1U7mFGtEwrjSDlqx271XVrNQzRAtnCxeVWu7/76sL4rgqiyRjV3dgLi7v6tqPVZiIhpc38vlvy6oj4re64KJ6pKyo3EHrYkYWSbj4jVsxVl1hxM1k1gny4hJdO9RKaubCY/DQ+1SkBOvsUnhYoyBCZlHMKX6YfQMDULf8/+EypRgqFWA/zw6quYlHYIOZIRao7HiyFxeDe8JQLcPW9hvkKBahQYTDAYXfsyTDXrMOzGFuwouC4/ZBf/WEyP7oxQweLYzY6G9n20ED2yfpZ/j/dvgp+DP0WeUBk5zS9hedMtMEHE08EN8FVU+5IuXSkDEMCxExyWrOBk/6mYaMD06FFMzN8nh818gA/D+9OqIUO6D8Hcedw7KBF5Gw7gZNLDyBUs4Qsia6ejzrOVsY2/il+yz2BTfnxhyE3BzKPW1dpoeC4O96mi0asbULu2axy3Z6bg1YTtuOGXJY/T+moWflqzFdXUwRDfnQypUniJDDLOcri4Bsi9xkEVKCG8ERB5NxDaUIKjYOmpaRxWrmbRyi1Wm7p1JDzaF2DhCFwtLF4U4yjPtTYQEy9Bf9MKVu8RCbHtXe/L1TGt9QpSOVxaC6QcsYyv8gOqdwGqdRCLPa8hh8PpXwHGR167phIaPA6XrVuO5hVZ2XmaGnefpyzrs5OMMZ/PKEwcbDu2N5G+bQOIehJU0zZ9jSfpVtx1mbFnXpqLDKvrDZuyXF8lxqqQomrJqq1yXiCWNJIV+8SR9uBkIfbDb0jNyMb1G2mw+kw5ym5tH5jNaPbsf2ylLR7PcXLaB7Pou39Yldg85amPo7p0tDm9FBDN2PzLOrR6ZjQMi3+GePUCNE8MRVafARiTsAe/ZJyRrT/RKn+Mr9oGg8MauCVUBJ6DJAKi3Evp5a+cePzn8iakmfUI4FWYGNsWQ8MbF2u0ZtY5dNjwEnjmxHKz6IOiMCt0Ai6YauN6zHVs6LoORsGMRyrVwsJa3aHilPf8ZqlOlq8SsXGr5bmaNpWwt/N2LMw8J//+shCNEVPO4AT/NjgY0OVdE4LqWI7axKP7cXrmFZzTPSr/LnA6NH04HzUeikSiMQ8/p57C7PTTSDDmFT5jpawQNDwfh4ekBhjcIwA1qztmmZivw38O78S2gPNyhaDcAEzafQRPHNwHhEUi8OPpQLjjm5LpF4GTy81IszyCwxLZBKjSlEeVphz8wopX+eewhCW/i8jKsqSA6f4Ah4e683I+5dLKmr8krFpn+XejVywgnbXUDokF7hsuILCMLnbmXJdw6ncR1w9ZxtcEAg1786jTlUPiP8CheWaYCgC1P9BsMI/YViXESSj9cYu9q/blrQQ35uFpVUfiwFbQsByEJf3nvaQx7Q0Bzr6v7PuxP21xN8WNuy4zjp7Dds6Oop6zMSZOX4TB/buhbs2qnuIvF+0qpKj66sfFmD5hVGH26dI2qf1xoW0iyF5d2sjZ0Af07YxWzS1+K/Ybho7/7vx9zo6FuiWuxDljNkbvPIbROUHQDx8H/vpV+H36kvwAug9+glilBo4a0vBu6i75JytNNeH4KrI9GqstV/GdFVeO/1gwyHFp+zA354zc3V3qMPk2Xw1VcX+fnDQjuI+GIcoUj+xOT0LT8xFovn8f/LULcrLfPa3+h5VX2yIpNAXruq2FQWPA/eqq+KVqFzkvnVIlP5/Db0s5sAjfTOy3f1CHn2puwC7dDTD5NjE/Ak9NX4zdfj/DzAegbl89otvbJZaTJJg27cbZjeHIlJrIUwsNvIy6z4dAUz1EFqGbCxIwP/u0/NN8U5TyIo+aV2uiW35DDL+3CmKiLKKO3cj7/OQ5zNYegF6jBy9yeCCpIWZum4dKV89CDAmFfvQUSOExt2DIT+JweQ2HzJvxtNiNutp9JMS11uLCCR3ST/FIOwHkxhcXEaxeWJyIsDiARTBnhVnsNm/lsHuvABYSISSEObJLqF/31v9s2YZMCJI4dNCKkFioBHYs1tGMWr2dC3Gl1tS2n7wEDlfWF/Fg0dBF3c1govVF1B/gOJCnJ3Mpz8d/jv6TbcvAU2sM+36qVT0G1gTOjk5bSmNtP64zP2L7vtx1mbFv78h65+g7l82TFetzerJ/ykObCieq3N0gbAOXZtmy3/D2G4hE1Z2/zdmx3zdZR9AkORM75m+A/qPZEMMs5gD1mvlQr5oLMbYOdGOmWUwO/y90luZeAAu7kCJafGyeCqqPMWH3Iowv/fjCmahi/lwv2zijjwi5G++FtXQI8dr479Hg6kpkBteGZvx0eW6c0QDNz59COLpbbpPbYwhWYDC2xmdhXbc1yPcvQL2CKCyp1R1R/q4l+i1tBVm+OOb3k53NyQE8Ow/MwVjVejCHfxYza2aCCj3mzcSBwG+RKTRD5XpmNB5asjhg809dcBTnTzaFmQsAJxlQu9ZhVHkhDpLWki6G+Vv9mnsOC7LO4rpYZL0KzglCx6xGaKwOw3zNIVwPTZHr18qMxsTQe/HAoo8hXD4tCyrD299AjIwt9mi6NA5X1nJIO2ax5LGYSrV6Sgi72yKA7B3VjXkcMk5wSD0GsBQstoU5eIc1ZiLL4v+UlsXjj9Ucrtwos67yAAAgAElEQVR05G7UUMRDLCffzaCZzG9q0WJOTnBcV+RQv8DCSM2SDQ+S5Ejot7uwQJ6X1/LIuWQRVHX6iYhhgTwVLO6Iquwc4HpS2QvNkBAOVSyRP4oV9m//+CkLMOb1wYX/Ybet4ImocuTz664oshcw7ubH88Rlxva5Hc3XkbXM0XetglvrjumqwokqZ6ZMa/iE8WOGytYn+99tLVVMUbONMGb8jEInO/vNQqLqjtnLDidyzJCGnomr5Pe2z1mDRu0eg/HBJ4rqiiL8Pn8ZfMJFGHs/A2OfZwvfY2lHvsk4hGnZJ+TXWO62d0JbYEiwJZ2Jo1KaqJrx//18lL5fbsZuHH4f2QmttI7PevIPHkHEjLdh4lTIHj0DfrWKx6RS/zEH6rUL5L5M93REYu/3MHeHCT83XovskGyEZ4ZhgqEnerTUWHWi2wvFglAuWyGAnXBHR0loOvAGXsndgHRRjypCAH49lIxma3/HVc1jOOv3GgQ/CS3eLor0XdqAphu5uDQ7GSkZDeRqwdJ5NOh4Bdpe7QuFLXt9c8E1/JJ5Fhv0xW8OsvcC9H4Yqb4PI6pXg2byuxAuHJed0fWjJxcTVCxwJkvlkvLPzRx2wSwgpoSolrfmpSvp88yctJllK+0UkH7ccjvPtjDH7dDGQLLAYd3fQF4eJ0eO79xRAotK/ssCDlkpApoZRYQbLW3DGouoN8D1G3huL6CHDZiAZOESXAkY6u4Q7oiq3ftFzJxfdOzt7lie1m/biscLT9tZWgH5u2LB8o145+UnC11LbMfwRlTZnoZ4IqpsLV2eiCp3XWZsn9vekMHecySqnPHzdL3utHYVTlQxwKU53dmLKFbf9kyc/W4fp8rWidDeCZBE1Z22pYvmY5REdL957PfOzmN471w69B/MgKQqfjTGjgG1nw8DJ0qytUqsVjz201VTDt5J3Ym/dUly5/XUIZgU0d6hIHIkqliYgZdubMFe/Q25ff/AOpgQ0RaBnGNLEleQD+m95xFgSMexu4ej7iuPOYSsOrgN6tlfgjMZIFarC/3rE7AvJQBD89YiJTgDQblBeHJ3b/RvHYhmTd2zOKxZx2PPPosIYTGk/Ltfwssp28CYxqkrY/n6o4jZvwP5Qi3sCpoJSDwaPSsirIl742Tuy8L5lRoYzMHgJDNqqFaj+uNhEFu0LfbMjOHstLOYl3kG6ao89DI2wtf1WiJEBDRTx0A4cwRSYBD0b0+BGGNxwCoMJcCew2xxsGZhBGJaO475VFpIBdvJMJ+57IuWI8KMU5wl2rlN8Y+WkOEn4VAyj2xeDjiOCDOH5gYRKpGTncGZFSjKzdyCd+4nzfWZuSOqTp6R8OdfZS+qGjfk0fvBW/0SnYkCb0RVm5aNC4/FPBFVbAWsvlyeiCp3XGbsV9tVS5Uzfq7voju7ZoUUVWWJnERVWdJ2b6wJ6f/gu+xjaJyahZ0zV0P/zrcw17H489gX1bpfofl9lvyFrPtgRjFribXuhoJ4fJi6F1fNufJLDwfUxrjw+xAlWI6tWLEXVX/lx2NU6g5kigYEcSpMjLxfbldaEad+iqAT23BJ2wzBn01CQClB3/n489BOeQ9cbhbESuEwvPopsmJrov/FDTipSoZ/vh96bXoIjdShcqiChk6uwufls2MqvvAYq08vEbsaHMLEDIs3c3dNDGYtWIOgi6cgqTTYE7sceRmBYBG7GzzpnqCyMjDrOFz+LRs3Tlr81gLM19Ao9DcEPN0LYk2LJcu2XDXnoIYQDM5khHr6h1CdPADRPwCGt7+FWLW2nKLl2hbg+k4BkhmyiIl9QEJsR7PD23zWvl0VVfbzyUvkLH5Yx4D868UFlkmQkCUB4aLl9aBYCQ1YOhcX0saUuknK6ZvuiKo77RF9cfzHnvHf4lNFoupO29F36HxIVFkWJi2Ng58/HGaxvx1Ld8SQij6Jq1nMEGyZuxZxte6F4bnRJU/F9hiw12AYH37OYV3m9P5T9klMzjyMXMkEf06F1ys3xfBKTaCBUCiqsoxGWYDNz7Vc7WK5+n6M7owYIaBUHML+TdDOmoACLgC7+s1F2x7OkyfzmWlFDuwqDYzPj0Z+i/Z4MWkLNumuQWvQoMfGXohMjUSd2iJ6dJdQxUGi3YREDgsW8cjN5RAUKOGxgSZ8pd2O3/MtKV5eUtfE5z/OgZCSKFuFzt43C/H/REJTScI9b4ry8Z83JfsSh3PzDNDnWURqrGEV6jQ8BnHAs7c6nJvN0Ez7oEhQvTEJxpj6t6RnqdJeRPUukhwqwVnxVFTZ9susVuknONmKxaxZtiW2s1k+dvw3l/Isqjx1VHfmeO7s9p8zy5Wz23/OYjU6c5lx1t4qDNlPZi0ryVJGjur/5k++G89OogqyIzPL/9awgYjBHlor3EDutCo7ouqUsAJXTDl4e9cxjD1wAbqP5zoN/lh4DGg2Qzf2h1uOAW0HZsdRn6Tvw7Lci/LxDrOcMKvVk9F1cSA7Gc8mbMYlU7Yc92p05Ray6OKdBGfgs9Kg/nAIBEM+lkSORbcPurgcsdvegd3Y8yno+z2H15ItokgtCui6+UHEJlqct+9uIqFbV1EOJMrKwSM8Vv5uEQGxsRL6DtThpdz1OKRPhQAOXwj1MGTKN7JFTAqLQurAKTiy0OLN22SoqKij9ZW1QMJWyxGtRkxFnGEyKt8fCVPvZ2Uxx8JiaH8cJzvrM+d2/ZtfIeFqQ8Rv4goTCUfdK8r56Jjgc7UoIapsx2IWuIyTHNJOcajSTkSIizG3XJ1veaxXnkUV4+0spIJ1TWwDg7oSIqG0OFWuhEgoLU6VM1HG5uzMZeb98TPw2ZihJYZDcBanikIqlMdP622aM4kq4JPxKvlqOSv/eVpE3TqeHQMptYSfpe+XncvjMvKw66eVMD41EsYOfVzqXr1hCdTLLeEVdB/OdNrmkD4FY9P2FIZgaOUfif0FlltpdVUhmBbVGXdp7AIcldCr9tt3IJw5jMN+nZEy8EPc39Z9fxL1qjlQr7E4sJubtYPh+ffwv9xjmJFzUn7t6fMPQLvLEuWcldatRLAYVPsOWARVq5YimvTIwNNJG2VRyo4sZxZURffp34Az6GTfrYLhX+Dgz2HQp3Ng6U5qP6z8erOwB2d/BfKTLA7DUcataMj9BL77Q+CunoHq0N8QNYGI7/4DLh+JhTH7pvP3XSJqPeSZk7XSosrp5vkXVijvoqq04J+OllMJMcFEWYfWTQvD+ri7bZjg2rH3qNvxs6zjeNue9eOJv5m7z3mn1CefKi9X4t8uqi5e4jFnXtExR3i4iJGvKv8l6+oyHdSnoO/1P+XqO2avQVxAFPTvTnW1uVxP++XrEC6dgrHHkzA+8oJLbVnqlU/T9yGDXRMD5BuCH4TfCy3LYutCUW9ZAfXiacgUwvFDzVl4ZVQA7PzpXejFUkX1z1Zofv5M/jsLFcH8rKbwSYVJpN/h28HvrzgkJhb3/2GJgo2NE/H8jU3IFo2IFvyxJCkQd8+aLPdljmsBw7D/4fzqINzYx8M/UkTzN9xP9Ovyg/z/kWPiDh5X13MQjRxUUjYa6KajqnEdrvv1woXw16HL8ZO7q1TfIqYCq7pumbKfB4kqd1bGs7rlXVSxp3YnTY23fkTO/LhcWQVvRZm37SlNjSurRHUKCfzbRdX6DRx27hZwfzszTp3ikZ7BoVcPEW1bl72wYkE1u177XT52e2vPSXyw7RB0//1Jdl52p/ApidB+/AI4sxn60d/BXKuhS81zRCOm5R/F/ZoqaK9xPWownxQP7WcvgTOZMD38G8T1a4r7vLwZZuvALgUGw/DaeMyP4PF26k75Wd4OvQfdE5pjw0YeRhPw9CARf4ecw6iUv+X3m2nC8evhVFRZtVD+3dSqi+yTlnlOjZOzLCK66etm2fHa14X5KZ1fxiHr3M2QCFI2jFyIPCwbv+ZDysR5IlHl65WsGLn/fE+JRijPBMhS5eXq/dtF1dTpApJTOLz4vBkGA4dfFvDQaCS8MUKUnZ3LsnyUvg8zsk+iYY4ef/+wDOjwMAxPvuZwCkuWCbL4Y0lxHZXCY8DoatB9NNvlx3AW/NNRR36fDQN/7SL+DngUW2uOwJuvu3/s56hfWwd29r7h2dFY1awBhqdsA3O4ZwFNv4y4HwUFHCbrDmBq1jG5m27+1TDnr4MI3LVB/p35Zxn7PQ9zPod/vuJhyuVQo4eEal2UmaercFmcqYt/cGC+SvaBO13to7R6JKqUoFh6HxXBUuV7SjRCeSZAosrL1fs3i6qcHA4TvxFkEfXBe5Yv2HkLeZw7z6PFPSIe6Vt21qoDhmT0S1wjz2HrnDVommuG7tP5kNiVRLuybz+P1Wt5VK0iYfjQEoSBJEH7xWsQrpyFsftAGPsPdWmnuCuqWBgHFs4hTVsdk0J/Rt9HVHJcKPuStJuXI3i743jN+mB+UJqZnxdGYDd2fRxbevfB88lbwIKb9g6oKaeIWZtvCa75SkBDfPzrCginD4HlpDE8/SZM7XrK7536hUfGCV5O0dL01bIVVFYeLMp51nkgopnygp1ElUtb3KtKJKq8wkeNywEBElVeLpIvRFXDKwuQKxmxJKYn2vndmrvMyykr1vzgYR4r/+ARFydi0ACLEEhL5zB5qsWP6OWXzA6v7is2gZsd6SQTuiT8LjtWv3XwIj7YsBv6Ie/B3KrrLUNlZHL4bpoAk8nyVotmIh7p51j8FR4DmkyyX5Yrx4DuiCrh4gloJ42CBB5fR/wEU0wtjHjl1rmwuEv7xgkQtBLqPCIhsoX7YtU2Aru50T3Y/8JIDErfJsfPspavA5vj2elTIVy/IsegMg7/CKYmreS3mZXo3GJejvN0z5tmaMOUFzVK7wt3+yNR5S4x9+uTqHKfGbUoXwRIVHm5XkqLqn36G3j0+lp5Vr0CauDnqC5eztB3zX9bwuPEKV62SDHLlLVY/ayqV5MwdIjvLRr/TduLWTmn0KBAwt4pC2Fu0Az6UZMcPviMWQLir3GoVUtEQgIv31pkAS5L8mFSb1wK9bIfIUZUgf7DnyGpNaUCdVVUcfoCaD9+EXx6MrZEDsGfqmfw5AARjeNuFUzxGwXEbyhyKmdRy+s95lrsJdvJFovAHl0NJ179AI8V7AcTpbM0zdBlyufgM1MtkclHfFEYeJP5NB3+mofZwKHuoyKi27gv6ny3C5XrmUSVcixL6olEle8Z0wi3lwCJKi/5Ky2qrMl/rdM6UH0AqgilhNT2cv6eNmfX8D+fKECv4/D2G2aEhBRZLljy2G8m88gv4PDYo2Y0u9t3Vg2W+qX/TRG6Zd56NLuRYUmYHFHllkfbuZvH+g28HKB05AgR8fGcfFzJccCQ58yoWd3BPG2PAbv2h/HxlxURVZr5X0O1cy1ywuvhY/WPiIrm8OpwxwKUWamYtYqFLojfaInFxBLxsrxxoY3cEzjFHNgDgnDl5bHIEQQ0+W4ceJYeJywK+jcmQowscrQ/9oMgJ9mt1EBEkxfcG8/T/XU72pGo8j11ElW+Z0wj3F4CJKq85K+0qHr4+p/4R5+CmupgXDHmYETI3XgvrKWXs1S++dV4Dj/PFhAZIWHEK7eKgX8Ocvh9tSA7go8aYYbacZo7rybGfIK6JKxEvCkXo04m4cNVmwqdqu07Tknl8f2PPIsbiWeeElG/nkUcbN7GY+s2Hv7+Eka87NhxnU+9LluVWIBN/dvfwFz3rhLn7YqlSji2B9pp/4Wk1mJK1VmIN1TFM0+ZUb/eraIueT+P80v5QkFjyuNwbgmHjFOWm3AsfxzLI8eO5VwtFgf2sbJzvG1hOQ/1r38BKbgoinvidh6X/+Qh+Eto8Y4IdRlfPnD1mZSoR6JKCYql90GiyveMaYTbS4BElZf8lRRVLO1Jwyvz5RltqPMwul/8A2G8FsdqDPJylso337SVx7btPNq2EfFAdwOYRAngihIVM0vW9J8EJN3g0LG9iG5dlLdwjE3bjbk5Z1DPpML+r+bKVhZ2U8/+iI7NZdqPAm4kc2jRXMIjDxeJQPYes1adv8CjSrSEl140Q3AQWkq9ZTnUi6c7PQZ0JqpYRHK/cS/IkclPtnkLs670QdWqEoa/6MBKJQEHJ/HQpfJo/IIZlRsUia7kAzwu/s6DuURpQyU0GCQiuKbrFkHmwK6e84UcRJMVawwqSVuURqcgmcehby3JiD1Jlqz8rvNtjySqfMuX9V4RRJU7cap8T/TOH4HiVN35a3RHzVBJUbUu/ypeSN6MDgExWFfnYbQ+sxTHjen4NqI9BgTVu6Oe+8efBbBccc8ONmNb5El8nXkIL1RqgheD4xDCW/yOriVw+GmmAIEHRo4wo7IbKUOcPexOXRIGJq2TU6hsXrwNTS/Fw/Da54WO1bbtmSWKWaSY1eyNEWZo7Kw6BgMwfQaPtDQedzWWMPBxx8dwfpNGgb9wHMYHHoVx4CsOp+hMVGmnfyjfxDM2aY2P8sZDr+fko8daNW4VRBmnOZyaLcAvQpStRPaF+TqdXcgj5yoHlgGnaiczaj0owcV4o3J3zIGdS78Bw3PvFuueJSI+MkUAi2we2UJC/Sd87xvnbM19/T6JKl8TLv+iqrSI6t5GDWeBQidOW4TxY4citFKw24vhbrR3RwPYJ3d2dxIlMfCWjbvzuJ31yVLlJX0lRdWYtN34JecMPoy8F+9Gt8DMpNN4PXU77taEYV3Vh72cqXLNdToOn39pEUsfjDGhTeISJJrz5AFYguHngxvipcp3I5L3w9LlAo4e5xDXUMSgJ5SxVrFjv84JK5BgysPIazp8tGCZnJJFP3zcLQ/JLGU/zBAgisBzz4hyQmFHhd0K/H66AIMR6NldRLu2t9bj0m7A76Mh4EwlHwOWJqqYDxXzpZKCKmFDt9n4a2+ofOTHjv4cleM/Cci+wKHe42ZEtSrBCiWxPHkCrjBHdjPgHy2h0dMS/KO8Y311HY9rW3iogyW0eNv7ZMnK7T7f9USiyndsrT2Xd0uVs9x/Lwx6yO10MLZ59+6Oq4PpE0a5Japs8+5ViQ7Hj1++VWKOvpJW2Db34Cejh6D/Qx3d2gy2uQcdMVAiXY9bE7qNlUlUeQlfSVHVPmEZLhlzsKnmw2gTHIPk3ALcc/U3+dr76ip9cI82wsvZKtP86DEOS1cIsiDQPHwab96M0m3bO0vP8kRwPQxRN8OiqSFy1O4Xni/BGdzNaY1O24UFOWfRAP7YMWk21LxgcU4PiyrWk9nMjv14MH+q++4V0eeh0oUGi69ldVxnOQwdCTDV5hXQLJlW4lFjSaKKS0+2HPsZdMh+aQLGr2st3zxkzunRUbcKJmYhOvyNIPsw3fu+GZyTbDd5iRzOzOehS+PkujV7iqjaQZQtWO6WnCscjk0XwDJF3zVMRMhtzuXo7vw9rU+iylNyrrcrz6LKKl4G9O3sMA+ft9aYimypYjuE8WHFXcHm+u66M2qSqPJyHZQSVYmmPLS6tgQhvBqX6z8LrVpAZq4BEzIO4ruso3g8sC4mR3bwcrbKNF+2UsCRo5Z0NO/ELpXTwnwf2RGPBNbBEUMavsk4hI0F19h3MlTg0DavDqI3tEA9TTBeHS6CL0oV6PaEbI/9Nv15CM2On5Dz87E8ffZlwyYeO3by8rHj66+aXcqlx/zEmL+YVivhteEiKtkfWbLbgJNGgcWYMnXsC8Og14sN61BUiaKlzaWTMN3fC79Hv43du3k5fAILo+ConPtNQMpBDjUeFFGtq2tWJ8kEXPqTR9IuC+Dg2hIaPCHKPleuFuajdfArAYZMDlU6iKjdx7WxXe3/Tq5Hosr3q+OOqJIy02FOuOz7SdmNwFcKA1+t1i3jOsvDR6Kq9MTJzJq1ZNVWjHtnCPz9Sg9NU+aLruCAiooqR2bIqtER+N/EWWjTsnGFVKhKiaoFOWcwOm03+gTWxLxq3aC5KaqY2Gp9bQl4cDhSYxAq3/RXUnAPuN3VhImCHC4h7qXzeFu3FdWEAOyJ7gtOUxS9/KwxC99kHMbq/EuyEztTWLWu1sSrQffgqZZFt8vcGZzl1uuUsBw3zAV4PVODcT/OhlhCGhnm78X8uZgjOkuhU8NRuIQSBmepdpjjemSUxYFcXeR/L7fg0pLgN47dBtTL8bBYXCxrcSSq1OsXQb1yJqTwGKS9OQNfTguS5/XayyIiI24VLcZcDgc+EyBxQOsPzBACXBdFbB5Z53mc+ZWT08mwgKG1+0mIaumaOLqwTMCNfVyZJEt2Z+3Loi6JKt9TdkdUGbavQ/7UT30/KbsRNB17IOC1/94yrrPkyCSqShdVzviV+UL7aEBFRZXVya1XlzaYOH0RBvfvJp/tVmSFqpSoGpayFavzLuOL8LZ4KaJxoahi6/5i8mY5jci7oS3weqWmPtoKrnV7PYnd6lMhJFjCmoHLcMaYiS9T/PDir4tg7NgHYpf+EEPCCju7bMrGlIyjWJZ3ESaLvEIHTSxGhd+N1lr3osWzY8bfcs+hFh+APZMXQpufB/0738Jcp0mxybNo6SxqOvOTattWRK/urgkKaye2jusl+YKptv4OzW9TLceALCio1iIo7UUVn3ARfp+/Akgi9G9PxoqTTXDgII/mzST07+fYl+rKGh4J23hEtxZRt797c7c+g7mAw7mlHNKPW6xWoXEi6g8oPWBo5lkeJ2fy4Hig2UgzAmLcE3Ou7aA7txaJKt+vjTuiynR0P3TLf/H9pOxGUDVtBb/+z5Ko8oB8acKSRJWbQG1vHjDrlK2o8vas2M2plGl1JUQV++pqfHUBskUj9lcbgHqBIcVE1d+663giab3s+H2wxhOy1ep2le1/89i4mUdAx3h8V2s9wnktjv+0Cn5pKYVTMrXtAVOPJ2UrkrVcN+fh1d3HcSDmLMwqi5hopYnCyNBmeMA/1unjbClIwNM3Nsi3/dbsu4H7tmyAqXW3W26tsY7Wruexey+P0MqWYz9HIRKcDcgEGfPHYrfzuj4gohPzT7IrhbcB2z8E4+BRDkWV37gh4JPi5ePJ5M4v4tvvLM5Rb40sHjDV2rVoBPZ/LMjRy1u8Z4afG0d3jp4p9RCP8ys5iDpO9s+q/6SEyg1ufRY5WfJEXg4sWqOniGoPeCbmnHG9k98nUeX71XFHVPl+Nu6NQMd/znmRqAIUs1SVJqrIUlX6ZjxsSEXvxNWoqQrGrmqPIUArFBNVrHW7a8vk3HYzoh7AQwE1ne9uH9WYNVfA5Ssc9j+9Gkf5JHyYHYxR039wOJrprvtgfnAgzPUtx2PJKRy+mmPA0bijOH/XaeTDKL9+lzoMI0Kbys/lSDCyY7/215YhVdThNXM0Ppn0NST/QOg+nivfpLMt1qCkLEr6Sy+YEVvVc2vLxUs85s7n5aM6RzcH5duALCioQSdHITc3bF7MUqVZMh2qzcthrloL+rE/YOnvGvkmZGlO89d38rj0By9bluKeU0bYGLI4nPmVl6OisxJ1r4ja/UQINm4Np+fySD/JI7iGhLtZMNfbp9t9tHOdd0uiyjkjb2uUZ1HlqaM6+/776sfFTm/1lWR8YK+/P34GPhsztNRbfSWFVLDO2xUXHEchFdxpX5qoIkd1Dz49DNqef05izOuD8d2sFfLxX1jlYLz83jcY2Lcz+VSVwHRK1lF8kXEQzwQ1wISIdg5F1dyc0xibtgf3+8VgcUxPD1bH+yYs3MDnX6iQGp6KFb1Wyk71x+duRnDiVRiGjIGpVRfwKQlQrVsEYe8mcGaLaDLXbCCLK1PzDli9ToV9B3iE19TB/MgJzMw6UZjUt64qBK+FNkX/gDpQsTOom2Vkyg4szbuAWqog7J6xGn7JCTAMGglTxz7FHorNb+o0AZlZygUctVrmmOP6K8NE2fplW1TbV0Hz6xSIlcKhHzcboRGVkK8zwXjiELTfvA1JpYL+gxm4IdTA1Om87KT/1htmBDmKTC4B/3whgMWfavKSGZXqei4Ib1ltCUj8m8eVtTxYDCrbgKHJBzicXyJYkiW/ZXbLsd37XXXn9ECiyvdrUZ5FFaPjLKSCleCcb98rvCHIhAorbw4b6BCwbUgFawXbsATW79WSHLxtfZmt7Xt3bVPoEO6KKLMNqcD6sA3N4Ep725AKjhhQSAUvPlvO4HrR9R3ZVInjvwFJ67BLl4SfIh9A78CaDkVVgWTC3VcXgf3cEvsoGqiLW2jKAs6pMzx+/Y3Hjt7rcTY8HqMKQvHhFItfUcEn82B7rY9FDFdtXAomOrgCSwwrMbwKCjo9jkkHH0KO3g8D+5tRp4lRjor+Y+YxpIg6uV6sKhAvh9yFp0IaYFdBUtGx3wUO9y2dB7FGA+jemwo5aZ9N+WM1L/srMefvV4aLchwtJQp7Zvbs4eEiXh4qQmN3cUU78Q3LbcB2PRH0yhgUZGRBev858NnpMAx4GaYu/bHwNx6nz/C4v62IHiX4eDH/p9PzeATGSmj2um+CbRbc4HBmIS8H9WQlpp2IlAOcfNxYb4AoW7H+rYVEle9XvryLKncDbCohJpgo69C6qcMwDq6sGPtO3rH3qNvxs6x9e9u+JDHqytzLYx3Fjv/K48MrMWdvRRUTSfVupqY5XWMwgnk1AjkjVKlJyAqvXmyK/03bi1k5p/BccCN8Ft5Giem71ccff/LYcCELyx9eBj8IOLZsPyLOn4LxqZEwdihuNbJ2zI7GhF3roPprMfgMi9+VURuMbap+OBT9GIa/GVTo88SscVMzjxUGEo3g/aCHGez471V1bXz6qeUmkG7MNIg16hebOzuqmzPPYgkaPtSMmGjlrDwsxtYPPwtISeZQr64o5w601XPsubQsBpW+AJrRE6Hfvg7cnk3ycSA7FmQ3EVkEepb/cPQoM7R+jud2bJoAFiOqwSAzIporN39Hi3x5LYfErUXBryo3FNF4yL9XUDFGJKrc+ufAo8rlXVSxh3YnTY23ztnO/LhcWQRvRZm37SlNjSur5KCOuwrew2HuuGbeiqqtukQMTvoLLT2M2JIAACAASURBVLSRWFWlt3xN3++dgeD0+TAOfgPG9r0Ln/miKQsdrq2Qc+wdqvEkgmxy7ZUFmEnfCPi9+RZcrH0RLxkj8MXXk+WbfrovfnNpeNW+zVCtXwQ+8VJh/St1eyP62cchRhU5tf+Wdx5TMo7gsilHrldfHYLdy/ZCOHUQpk79YHjytWLj6fQcpnzPIzeXQ5fOIjp3VF4cZGVxmPqDxXGd9c/GsS3qv9dAveCbwpdE/wAYPpwJsXIE5swTcPEShy6dRHTu5HhuufEcjk4VoA6RcO97zoN9ugTcSSUm4M7+ysOkQ4VPluwKLxJVrlDyrk5FEFXeEaDWFZ2AYpaqO0lU2Z9R255vO1pQ9r+JYaO/wvUbafLbJYXpd/Q/FG9F1Ufp+zAj+6QcKoGFTFDt3QTNnAnyPMSQUOg/nV8sQfCgG39he0EiPg5rjRdC4spsf6amcfh8bgEWP7oIAsfh8LpTiD3yD4z9X4Kx+wC35iEc2wPTmhUIvHywsJ3pno4wd30U5rp3WZ4dElbnX8b3GccwKc0PradPtPAYNxeSX1E8LFZ32QoBR45xcmTyV4aZ7U8F3ZpbaZVtHdeZtap+veICSfvtOxDOHJa7MLz4AUwtO+HyVQ6z5gjw95dkXyr7vIPW8Vg09LRjPGr1llC1o2+O/hw9m1nHoSAFCHIjjpdiQO+wjkhU+X5BSFT5njGNcHsJKCaq2GN4ayZUAoX9TQVnTnZWAfbWsIHymbX979Y52fqK2Yo0b0VV14TfcdqYgaUxPdHWLwbaKe9BOPWPLBw4XQGMjw6F8cEiB8e/8uPxfPIm+abgzmqPldklLRai4P2snTjT4AyeRCSmf/EtpIAg6D5fAEkb4NHSrZ91CTWP/4YWBZsK25trx910am8vv8YsdtqPhoDPTCt0hrcdzJpahheAV4c5Dqbp0eRKaPT3Lh5/beRlcTT8JRER4UXCimepaD55EWKzttA9N0bugR0bJiZy6NFNxP3tHFup2O28A+MFOb3MfR+a5YCdVMqeAIkq3zMnUeV7xjTC7SWgqKjy9vxYCRT211KdXQe1F12O6lv7HP3qIIwdPwNWAcbm642oYiECml1dBA14nKv5NDRZGfAb86QcLkA9/H2YvhkLdoyk/3SBLGBYYRac1vFLZb+jhdHd0cmFGE9KcP1+qR4TWvwGiRex5+8ENNi5FcaHBsPY9zmPu2e39FjcphBjMl6p8StCj6wBZzRYnjMyFuYHB4C7dhGqbX/A3LAZ9G9MKjZWQYHl2C8vn5Odv5kTeFkUq+N65coSXn1JLOYjVfnUbujqN4NOFYAzZ3ksWMTLN/3eHFlympxLq3hc/5tHlfYiavctm2coC07lbQwSVb5fMRJVvmdMI9xeAoqJKkfXQm0fzZPs256gcRQTxNmVVvb+ms175ezerEyctgjjxw6VM4Xbii5reAhbUZWUbrmx5klZmnMBI1K3o2tANcyP7g7VhsVQLfsJ6NQb2hdHo2Dca+DPH4OpxyCYHn2hcIjvM4/h04wDeDCgOuZGd/NkaLfasMTEvdbtx7HGx9Gbi8L8Cd/IR5KG8YsgBYW41Zd95b82cWBhCyIjJLz+XA7Uu/6E8NdicDmZxaoaxrGUNMUd9xcs4uRbeSwW1fAXizuPezUpJ42Z4/r0GTySkznUqS3h+WeKxg4NUiNfb4LeKOHbqTzYsenDvUXcd69j65NZD+wZJ8hhDu4bK0Jjn2vQlw9CfRcjEBPmB28+z4TTOQHGmAoRqMgEFBNVdwokR4FGnYkqWYj98BtSM7JlvyqrT5W9n5ijo0GRRYb0sPzn8mbMTz+Lr6u1w8iopsh96xmI1y5jRvQUnOHvxphHziF8+kuAWoPgqYvBVQ6XR0o361Ht6FwYJBGX7noa1TUWK5avyr6zerTP/EWOhL7vSCbqr/sTmocGwO8/xZMJezI+Swnz/qcmZGUDTw0Q0Pl+y1V/4+bV0P+xEOL1eGgffQbaJ18q1v3+QxJmzDXLN+r+964KURHujV6QDogiEOhmO+soqenApxNNyC8Aenbl0L+v5SYdx64FSsD+QyJ+mmtGRBjw+Yd2yQNtpnruLwnHlpgR2xJoPbzkeu49HdX2hADPcfDm8+zJmP+2NowxFSJQkQkoLqpud5wqdy1V9seFVuHEgpU2a1KvmAO77Uaw+lV5c/zHjv7YEeDm2H6Iu5EOv8+GQx9SBe8HLpSHatRQxHOZH0J1eKecV884aGThFKx58Fg8pw/C7vXpHh3+zxGsCj+EZrkR2Pr9ZHks3fhf5ZttSpTDRzksXynAz0/CqBGi7NRtLarDf8Pc5L5izvq5eRwmf8dDb+DQu6eI1ve5d2SWuIPH5dW8nKj4npEiNHYBPV19pivxFid0pqsHDRQR10iUI6rn5psw4RsOmZkc+j9iRvOmJQvv/Z8KMOZwaPqamZzFXQXvo3p0/OcjsDbd0vGf7xnTCLeXgKKiypGgsd6se+U//cokorq7PlXuWLYcWao8FVWnDRnomvg7WCymIzWehGbJNKg2r8CROs9gXsGQm1YP4N2nLiPiqyFyoMuCj+dACq8iv3fckI4eiX8gmFPhaM1B0KAo5pCSW0onmdDk/GLo1Ab8eqAAPTctB8vtZ3j2bSWHwY8zBSQklJ7CxTrgLwt4nL/Ao0Y1CS8Ocf+m3JEpKuQlWHrzj5bQfKTnIQx27eaxbgMPlQoY/qIZjeqqsWWHGcv+4GQn9hGvlHwsmXKIw7lFAoJqSGj6qvvPoegCUGcUp6oM9kBFEFXuxKkqA6R3/BAUp8rDJSotL1JZ5v5zdvvPKvLGjxkq3/az/93WUtX/oY7FaCgpqn7KOoFxGfvxeGBdTA5vB/93nwCLQj4xdgFuiFVRtzZw4RJwf1sz+l6fCNXu9TDd+wAML4wtnNPD1//EP/oUfBV+P54MLh4M08NlvKXZt8knMDF/P6LTQ3Fq9g/gTCbomH+TTVwpJcZKvM7hhxkWYfjacDOiohxbdw4e5rHyD8vtuxGvmFHJTR8kXSqHgxMtKVlYTCh9GoeI5iIaDHLP2mX7zEuW8zh2nAdzXB/9uoAJ35iRncNh0BMi4hqW3O+RyQLyEjk0ekZE2F2ej68Ef+qDgn+WxR4o76LKUegg+xQvJYXkcca3pNx/ztpZ31cirJGj3H+ujs/qlZT7r7ScgO70Xx7qKmapKm1Bvd0s7oIsLU6VvYhifdsfWZb0oVBSVD1zYyM2F1zD5IgOeOJiMrTTP0RulSb4CFNlp+0hTwv44lvLUdj7Q29A+8HT4Mxm6P77E8SqtWUky/MuYMT/58VjCYnXxz7sLian9Y2SiGaXfkMWr8fn2yW8vHshzC06QD/0Q6dtPamw8nceB4/wqFVTwpD/3Gq5YbcFWf48g4FDv74iWt7jvhCJ3yggfoNFSFXvChyZwkM0ArX6iKjawf3+2HMyx/WfZwq4foNDQACQnw9UrSLJkd1LKlkXOZz40RLss9XYf2cCY0/2iC/b0PGfL+la+i7vospeHLD/xE+fuxLPP9lLvthUUkie0sjafl95cqHLNvefbc4+d1bTVhh6Igptv0Nt8xZa56BEuh53nud21lVMVN0plqqyhunJ8Z9JElH/ynwYIMpHf1VnToTq4HbsjXsDSzL74cGuQJ8ePL76zgzmt9Ovj4g2l6ZBvXGZ7F+kf+0z+TFZP83iF8kJif+o8hBaaqMUffx5OWfwXtpuhGVUwuk5c6A25MvJgc2xtRQdx9oZ85X6dooAlhj5yQEiGscVFzmzfuFx+TIvp4p5drBnAkhOWJzOodFzZoTFSbDm22MBv+4eZkZwbc8uHjDBN/0nHizMAyv/eVpE3Tolz/HUbB4Zp3nU6iuianvPnsUni/Av7pREle8XvzyLqtK+42zFw/8mzkKblo3ddnfx1vhwJ1uqZCPAmu0yJvsTIN/vurIdQTFRZYW2eNVWTJ8wSlbtrJS1T1XZ4vMsThVLnsySKDdSh2JzRHf4vdVfnvanVZcjyxSCd0ZKqB4rYNd+ExYt4REZKeH1ZzPhN/YpsFx6ure/gXgz8viXmYcwOfMIHg2sg6mRxY8rvWHB4mG1vbYU10x5eGWDBp8dnA1zXEvoX7dEe/dV+XuXgL82cvKx3lsjiyw9+/bzWL2Wh0Yj4Y3XRAQFuS9+cq8BR79TQfCX5CCb3M2Ey1fX8bi2xeK43mKUKFuPPClXrnKYOUdA7ZoSnndgabP2qcvgcHCCAEEjodWHZvkoksrtJ0Ciyvdr4I6oumEqwKmCDN9Pym6EaLU/4vxCbxnXlTx8jk5CXH2Aii6qytINyFXmvqinqKhiE7zdt/98Aam0Pj2xVH2RcRBTso5iaEhjfHoiGZqFk5FZrwM+zfsYYWESxr4FaNQCMnIMmPi1AGbBee5ZMxqenAf1qrkQazSAbsz38rRSRB1aXF0EHhyO1BiEyrxGEQQr8i7itZTtCMoNxKmfFiPImAndqEkQGzRTpP+SOhHNwJRpAtIzinLlsb9/N00Ai5fl7DZdaZO7tJrH9R08oluLqNvfxjokASd+5pF1nkdgVUm+iceim3tSjh7RoEoVMyKjSj76u7icR9JeHlU7iqjVm6xUnnD2RRsSVb6gWrxPd0TVvLSzePZyUbYF38/OMsIzYQ3wS+2utwxXWnBr2yM8T47P2GAVXVTdCcHBy2IPKS6qymLSd9IYnoiq3omrcNiQhnlR3dBr+lcQzh/H1uafYPWN9nKy3j49OFlUZeYasG0Hj01bePm6/lOP6uD3/mA5MKb+5Y9hbtpWRjEsZQtW513BO5Wb443Kzb3Gw+w0XRNW4owxE89sC8SUPT9BrFEfujHTvO7blQ7OnuMx/1eLGemdUWYs+I2XU70wp2/m/O1RYbGjPhFgzONw1zAzQuoUt0axHHiHJ/Py0aA3jusspEK+zgSd0fE8zfkc9n4qgJOAlu+ZKdinR4vpm0YkqnzD1bZXd0TVhuxr+DzpH99Pym6E7iHVMTamhVuiylrZWQaP0h6GRFWZL7VPBiRR5SVWd0VVtmhA46sLIYDD+eBuqPTBc3Jamv9FrUC+QY0Rw82oWZ3dbrOIqvx8DhMmWcwmLNVJxKGV0Pw2FWJ0Neg+nAnwPHbrkvB40jpE8n44WOMJ2WrlTbHmFwwwaHFo6hpEGZOKiThv+na17S/zeZy/yMvHfLm5nBzDauRrIgIDPDuaszqGs4jl945x7BhekMwXOq7X7ieiSgm5+kp7BmeiKn4jj/gNPCKbS6g/iMIouLofyqIeiSrfU3ZHVPl+Nu6N4MrxH+vR05tuJKrcW487tbaioopdx0xKTse4d4bA389yDOWNcr9TodnOy11RtTrvMoalbEU7vxisPJAM9Z/zkHrPI5iQNBLhYUw4mBGgFQpFFRtrxe88Dh3hcX87M3p0McH/w+fApSVB/9xomFt3l6fzQMIKnDVm4YfIzugb6J0jea/EVThqSEO/3aGYs30qzFVryg7qLFZWWZXUNF7O62ctgwaIiLNzXHdnLheWCbixj0NsJxE1HyrZ2mXruN70FbMcQ8qdUpqokkzAgc8t1rLmo8wIiHGvb3fmQXXdJ0Ciyn1m7rYoz6LKkaM6E1qzF63Fy/95RP7OcxSSx1H8RkfcShJV9vlpS2JekqO6O9/BjkIquNO+NEFJjupuflro9p9rwN5N3YX5uWfxbmgLvDtxoiyO1raZik1XmqBzBzO6PCDdIqqSbnCY9qMgh1cY844Zqn2boZk9Xo5orv9kHiSVCtabem38orEsppdrk3FQa6fuOgYmrYe/pMLu77agZsFV6Ie8B3OrW30MPB7ExYZr/+Kxew+PpneJeNzWB8rF9oXV/j934d5PBJgLODQbaUJg1dI7uLKGR8I2HupACc3fcM9xvTRRxUQdE3eV6khoMoysVO4uo6/rk6jyNeGKF1KBEWNCZOavawrh2ftUOUuT5ihvrm1YAiZG9vxzspixwnalbEMqWF/v3bVNYX1XRJl9rC3b0AyutHfmS00hFTz4bN1Jcao8mL7HTdy1VLWKX4JEcx7WmuPQZtIHEMNj8EHQQjn20ivDTIiJxi2iik3u59kCrsaz5Lxm3NtSgvaToRASL8PwxGswde6HAsmEe64uQo5kwpbYR9FAXcmjZxp04y9sL0jE4xciMGPpZOgCoyB+OU8+ZizrwtLQ/DCDw7AXJfhpPbfqZJzicWoOD22YhJbvuiBm7BzXm71mhqsB60sTVQcn8tCl8oh7TkSoF1a3sl6Hf8t4JKp8v9Ll2VLF6LgbtkAJMcFEWYfWTeVg1Z4UJnh27D2KN4cN9KS5fPnMm/ZsUE+PRD2a8G1upNjxH1mqnK/kJWM22icsRwivxvkdyVD/vQZJ7Yf8X3tnAiZFdbbtp6p6NpB93/cdAVkENRJUohFFI0bE4IoiAROjIAiCATXsIkaNOKKIMQqiokZFvygKqMi+r4Ls27BvA7NV9f+fGnvo6emluquqq6t56rq+68tM19nut5q5PefUe/D8L/cULf2JWgKX/8TvNm6S8P6Hip5e4a8DVSgblyHtlZHwlr4EOWPfgzctA2OOL8P005tw9yVNMbHylZE7FHCHWPITS3/pULBg2nI0O70ZJ275G9JuvDnquqwqkJ8P/dBkM9fP7yk4ulZCnetFwk9jG93FxvXVU2XknZRQtYOGxr2NlQslVSe2Stg8Q0FahV/FLn4rqWbQXVRlKVX2h9vtUiUIRXNMjdk33ozu4woXObNSZrY8j6kx8b0SD9uI8dOROWkIGtUrXGNhnqoLQP99ZitGHPsJN2XUxTvjX4SUex4fXzMHP26pgq5Xa+h+TeEf7mBSJQ7t9aVXeOBeFQ3qe5E2+TEoOzYiv+d9yO9xN3YXnMFV+z5CuuTB6jp3okyUCZAeOvwtvjy3B32zq+CVV15EtlIO8ouz4PWYtBoTz5TZomIf05K/e+BVgY5PRfe23blDEta9ougZ1xv+QUP1KyKLVSip2jhdwantEhrepqF6l8j1mB03y0dPgFIVPbNoSySDVEU7Zt5/cRGwbKbKh80nUQezjhWRnPni8JinLhM9HNEs//mkZdLZSuj/r5egNmmLp/Om6kt/Ax8uQI3qhaMNJlXi9wu+l/HtdzJaNtfQp7cGec/PSB//CLyp6ciZMFt/i/DurK/x3fn9GF2hEx4u18owvp0Fp3H1vrn6W4kLPtyOVr8swdoWD6PJo3cYriMRbzyyRsK2WbEfWly0cV0B2vw58sb1YFJ1/oiM1c/LhUlHR6mQPIlIin2iVNn/DFCq7GfMFpwlYLlUOTuc+LduVKrEjqCmu/+Dc94CrJ2/C3VX/Ii9NzyBf667qUT28FBSJY5AmTRFgeaFnm28bFkv0l4bDWXtYuR3vwP5tz+Mb87txX2H56Oepwx+rH274eQKfzv6PT48+wv6yNUxbfwU5EoZ2DJoDpq0To8/VAtb9B0H06CnhhoxHgez6wsZBxb9unF9sIaUMNncg0nVtvcVHFklofZ1Gupez1kqC8NraVWUKktxBq2MUmU/Y7bgLAFKlUn+RqVqZe4R3HLwC9STS2PNxDfglT348Nq5WLq+NLr+RkP3ay/8sQ0lVaKrcz9VsGathN9cqeH67hrkrL1If+ZBeJUU5Iz9D7SyFXD5r5vhRXLRa0vVjjjCLPWcXkaFF4t/OITmP87H/EvuQYdx9yLVvSt/0BNtPluY46vTKDWsDIWF5AXWZyo4s1PSUyyIGatQG9cDpSr/rIQVYxV4JegHJ4cTsoiB4g22EqBU2YpXr5xSZT9jtuAsAUulyj9PlRiWOFjyi/lLEOvJ2c6iMda6Ual68eQaTD65BveeTsE/p81Efsdr8Ozxp/UDeP2X/kSr4aTqYJaEab+mVxg2WIWiAKnvTIFn8VcouOpG5N09GJmnNuDZEytwXana+HfV7hEHMvLYEsw8swU3KVX1vV75SMG/O3yAPz1YKmLZRL5BHAUjjoQp18SLVg8ZeOsvzGAKzhVmXBcb16tdrqHR7cFnnAKlyneuYNWOXjS+w1wfEpl1MvSNUmV/FClV9jNmC84SsEyqfLk2hgzore+f8j88ccOWHfjgswUh82w4i8Bc60alqtehL7E0Jwszv9+GWxcvw87bx+Ffi68osfQXSarE59PfUrB3r4Rbb1bRob0X8smjSBt1NySvF+efnYnTFSqjzZ5ZyIeGZbXvQE1P6ZCDPKbloMPeOcj3avh+1Sm0/vpzfF+qF871egRXX+XupaoNmQpO75B0mRFSY/YSG9fXvqTom94b36GhaseSfPylSmxwXz62MD/WZU9oyKjibp5m+SV6eUqV/RGiVNnPmC04S8BSqRoxbjqGDuqjv/nnn/DMbPp9ZxGFb92IVIl9VC12v6svr+385xyU9ZTC+10/xIrVnhJLf0akasMGCXPmKqhSWcNfBxX+oU75MBMp8z9EQfuuyOv/NIYeW4z3zvysb1YXm9ZDXeNPrMQrp9ajW0plfDzuFWgaMLbq+/jTwHJFG+cTmX+ovollN3HWn1im6zymAIo150zjyBoZ28S5hCE2rvtL1aHFMnZ8KqN8Ey9ampwpc2MM3NZnSpX9EaNU2c+YLThLwDKp8s9T1bhBLQwcPhX+s1ZTMudg2oTHUaFcGWdHbHHrRqTKt3m8fbYX8195D3nX3Y7ndj6iL/39+aEC1AzI8B1u+U90X9WAKVMVnM2W0O8+FfXreSFln0H6qL6Qcs4j5+nXsaVKRf3omjKSB+vq3YXUIJuAsr35uGzP+8j2FuDjrbno9smHWJbxe3xeYxiGD3X3UtWBhTJ2zZNRqbWGZvdYO0O083MZB78PvnG9SKryNKycqCD3hISWD6oo39T8TJnFjy6rCyBAqbL/kUgGqYomT1UgUd+KzuXtmsecjNP+KLEFMwQskyrRCf90Cr40+8n+EBmRqr8fX4o3T2/G4JXb8fQ3S7Ht3kxkft006NKfkZkqcc/CRTLmL5DRsoWGPncUSoPny3eR+t+ZUFt0QO6jE3DboXlYlnMYkypdgb5lmpV4Tl46tQ4TT6xCG08FLJj0OqT8PEys8g5qdaiFXre6W6rWvuRB9n7oQiXEytIrzMZ1n1TtXw1sfUdGemUN7Yda3L6lg2FlPgKUKvufBbdLVbiM6kazhkebld3+qLAFKwlYKlVWdswtdRmRqm77P8a2/FP4fNbXuCIvDXM6zMSKVXLRG3yBY400UyXuF7NcE6coEElBfekVhBSlj+wL6cxJ5DwxFZ9UL42BRxbqR9aIo2v8rxxvgf7G3zEtF+/slnDz7P9gR6Wr8Wrqs7ijl4pLW7t3ZiX3mISVkxTIqUCXMQWGj5iJ5pkrtnG9i4ZGtxWKk0+qlr8k4cwuCY3/qKJqJ/eyjIaJ2++lVNkfQbdLVTBx8j/3zv/MvnA0rTj6xf5osYVYCMRVqsQS4bS3P8EDfW5MmmXASFJ1VMtB2z2zkapp2D9lNrRbHsJz6+4KufRndKZK3PfRJwrWrpP0DeW/+/X4Fc/C/yJ19svQ6jbF2eEvo+PeOTii5WBu9RvROb1a0TMiZs7EDFoDpQxWvPgfyOfOYmrVGdivNMBTw1Skp7tXBPZ+LWPvN7K+Od3ON+6CbVwXUnV4ZwGWTS5cHhRZ3JnsM5Z/muJfhlJlP3M3S1W4o9gEOaMzVeJeK46fsT9abCEWApSqWKj5lYkkVXPObsPjR39E9x0H8cFHC7Bl0Ad446OKIZf+opGqYOkVoKnI+Pv9kI4dQu6A0Zhc/xJMObkGPUvXx2tVuuk9L/BquHzfB8hSz+PVrDTcNXMGztTrgGfynkftml487PJN1fpepuOSnkZBpFOw8/LfuN72ERV1mqdgWaaGw2uhJ/oUCT95uYMApcr+OEUjVbmngdMH7f3+BhtxelkJZWqU/CSSCEUjVZEEzf5IsAW7CFCqTJKNJFV/ObIIH2fvwNj5KzDgXBl80HAiVqwMvfQXjVSJe1+foWDfPgl/6Kmi/WWF/wB5ln2L1LfGQ6tWG3tH/Qsd932g/35F3TtRRU7H+2e3YfDRH1FbKYXVr86F5+QxLLpqCv67oz26ddVwbTf3isDZfRLWvazos0SdnlZhOKW8iedg539lHPxRRkoZL674i4JF4wv5dR6tQikV/z8KJoZyURelVNkf/mikavdPGpa/Gf+9nXWvkHH5g4VJg/2vSIcjRyNVol6zBxXbHy22EAsBSlUs1PzKRJKqFnvexWktHz+++Tka3jwQYxddry/9DXhIRa2awf/gGtlT5evCuvUSPvy4eHoF8Vnac/2hHNiFvHuG4OEmGfg0eyceL98OQ8q308/4E2f9TTpRBv1ffw1a3SaYVDYTR49J6P+Aijp1ohOB3V9JOLxCRpV2XtS/2Vkh2/W5jAPfy6hxlYYGt8SvL76cWOIMa5GfqprfPiuTjxiLx4kApcp+0NFIVdYmL7Z8EX+pqtZSRvObZEqV/Y9DUrZAqTIZ1nBStTHvOK4/8F9Uyc7B1unzsPkvH2HGexlhl/5Ed7a8qeD0XglN+2oo3yS8GARLryDqUDYuQ9orI6GVr4wfn34Btxz+P32W6tnKnTHw8EJUktOwLfNzSMcP48R9z2Ls/65GWroXTw1VIUnGoYiUASsnXPivunaDVZSqFp2UGW8t8p0i2Wb+aQlt/6KidJRyGLn20Hf4b1wXd7UfqiK9snMczIzlYi1LqbI/8tFIlf29ia4FK5f/OFMVHXs33U2pMhmtcFKVeXoDnj2+An027MDLx8vgo0pPYvlKGVddoeGG3wWXpfxsCct/Pa+ubH0vWg+M/F9qCxbK+HahjFYtNdz5xwv1pk1+DMqOjcj740Bc01zBpvwTyJA8OO8twOhzFfHYyy9Dq1IL398yE5/N85QobwTNjk9kHPrpwn/VlW3oResBkftspO5o7xHZ08WMUVolLzoMi38fsvdLWP+qggpNvWh2X/zbj5YX7y9O70XOqgAAIABJREFUgFJl/xPhZqmKtA8q1PKfeNMvME9jJEGzPxJswS4CSSlVvtxY6zfv0LnNfHG4fnROqMs/v5a457lh/dCrR1f9dv/XZcXPN13XpdhxO+Gk6k9Z/8PC8wfw2ueLcWv3gRj7WUd96U9sBBcbwoNdJ7dK2DTjwsxPqwEqyjUMP+Phn15h6GAVl5QuvF/e8zPSxz8Cb+lLMGPkP/DEqeX670tLHmya9T3K7t6B3AeG4z+7fofNW+Ri+7KMPHBidmbZM4V9vXSQqguFuJr2VVG5TfxnaX75SEHWMknfHC42iTtxnd+SAilDQ3o9SpUT/M20SakyQ89YWTdLlRhhpJQKPgr+f3P8Txfxfc6UCsaeFzfelXRS5fuviS4dWupiJIRp5PjpGDuiv358TuAVeGZh4M/iS1SnZlVdynx1V69asSgbbjiparTzbeRIXmx55zscvfttvPWOJ+LS3/6FCnbPk5BWFhBvv5RrrKFV/8iC8NHHCtaul0oce5OWOQbKmh9x5uZ70OZSD05qeXg8rzL+PvWf8FasirPPvINxk1ORnw88+YSK0lFsrN71hYQDixT9DDxxFt7e/0nYO1/RN2x3eFKF2F8Uz2vpmMJz9pxcegs8UDme42db5ghQqszxM1La7VIVbeJO8Tdj8rTZ6Nure9Hfn2jrMMKV9yQOAcukKtyD4jtcefhf78bM9+fZmqcq8JzBQMkKRB8oXZHuF5K1ZOWmotmqUFL1Y84h9D70FVocOYlF+8tibtpDWLZcxpVdNPw+zCzKz+8qOLpOQpt7ZGz6SIWYDRKzQGXqhZ/5CZpeQcxWZe1F+jMPwpuShjXPTsPxtBR0fH0yym1ei7y7/obt9XpixtsKqlUFHvlzgeEnU8jLsn8UHi7c/onC/UPif4t0BnmnJNTsqqH+TZFl0HCDEW48sVnG5pkyStcC2j5qfBxWte+rh1JlNdH41Uepsp+126VKEIrmmJrANwaT/YQR+5+gxG8hLlIVzwOVg61fB5t+9Q+N+Hzet0uROWmI/uvJr87G+Kf6B01QGlhXKKkad3w5/nV6IwYt24xR1z6GCW/XRna2hP4PqqhTK7QgrX5exvkjMrqOkrFndQF2fSGjfDMvWvaLvJz0+psK9u2XcNstKi5rd6GN1HemwLP4K+Rf2wtq5+sKlwQvKYec8bPw9aI0LPoh/D6vYI/xnv/J2DdfRuW2XjT904W+ndwqY9OMwgOHL3tMQ0bV+IjVz+8pOLpW0kVOCJ1TF6XKKfLm26VUmWcYqYZkkKpIY+TnFzeBuEhV4OyOnch9s2LPDO2HjPRUvalIUqWL2Gvv4+iJ0ziYdazYnir/vgYTNnFMTLCrw6qZWI3z+PCH7Wh90/OY/HIBKlYAJo4OvSam5gGfPJIPSQF6vZYC8fO8J/ORdxa47mkPytcN/1re0pUa3nhHSJuEvw/1FHXLe/woTg/8g/6z0rwN1C3rkHH3IKT2/BOee74Ae/Z5MXiQBy2aGnvtryAX+HxIPtRc4HfPeFC2ZvFyi18pwMG1XlRqLKHbkxf6YVfcRQqDTx/Nh1YA3DwlRV86deoSb06Geiac6hPbNUaAsTPGycxd0bxZbKYdliUBpwiYlqrATd7BBlKjWiV9FijYniarBx7tTFXgLJpverZ3z25Fm9VFH0W9I8ZPLzGOg8fPlxjCaS0PzXe/B4+qYde+Cph3/nYsXSbjyis03Bhm6e/MHgnrXlFQtg5w9XAZJ7PzsP87Gbu+lFGxpYYW90dOr/D8CwrOZkt46AEV9epeML6UDzPh+eZDva/etAzkTpqNs2ppTJisICUFGDm8AErJ1CxBw7PvWxm7v5JRsZWGFveV7FPeSQkrJhYuDTYTm9bb2rtp/chqCT/PUiDePLz0z5Fn9Kx+5vzrq3BJKs7nFiAn37nZMjvHl8x116iYgWDf52Qec7zHJhjzIoFkJmBaqnxwEmXzXbR7qozMbIUSKjH2YMt/nx7fjEGnl+KqPVmY034QJmaWL1z666eiTu3QgiFSE4gUBbW6AG3vkXHybJ4+W7VirAI1R4KRHFDfLZQh/q9VKy/uvP2CYEjZZwoPW849j/wb+yL/lvux5v/v3Zr7iYKmTTTcfZcxCRCzQivGKfper7aPqigdYilTnL0nzuCLx6b1TW8pOLlFQsPbVFTvYq/ARfrHgMt/kQgl7udc/rM/Nlz+s58xW3CWgGVS5ewwLrQe6e0/38za+BH99Tf6An8OnKkKNvPlP9ZgUjV042y8VzoHT/18HDc3H4I3ZyooXdqLJ4eEn0X55SMZWctkNP+jFw2vUXSpEte+b2Ts+VpGpdYamt0TXn7ELNXzUxV9Cco/vYKoRzmwGzh7ElqdJvBmlMKHcxWs2yDhpt9r6Hy5Mak68IOMXZ/J+pl64my9UJeYpVo1WYFIDlrrtxrq9TBWf7TPkXpOwlKR10sGOo9y/lgYSlW0EUyc+ylV9seCUmU/Y7bgLIGkkyqBM1yeqkCJEvcH5qLyz1Ml9mO9OWtesSj5L2cGk6rLN76O/aVT8eWpWth/6Ab8tFTGFV3CL/2JBsTS39m9Ejo+6kXVZhekSsxWLX/OA+3/77kyMlvlk6WuV2vofk1wmRHSNU5IT46Evz2iolKlyDM83v+/Z2nFBAX5ZyS0elhFuUbhy5zaLmPj9MJN6x2eUJFWMXIb0X4dDi2VsWOujAotIi+PRlt3LPdTqmKhlhhlKFX2x4FSZT9jtuAsgaSUqngiDZSqXw5vR9dzP6Bcbh42NuyHSS+lFS79RTpTzwssHukBVODayV6kl7ogVWI8od62CzbWvfslTH9TQUaGF8MGq1BKng2K/QckZL6hoGwZL5543Ng+pENLJOz4WEGZul5c+oixMlvelnF8k2w431a0sfOdudf0LhWV/d54jLYeq+6nVFlFMv71UKrsZ06psp8xW3CWgKVSJWZ1Dh0+rudwEtfoyTPwxfwliOdG9XjjDJSqfy+eiRE1gZ5H8/BUtQF44y1jS3/nsoA1L3j0fE+/GQWkphSXKpEXavk4RT+sV09uGWFm6dVMBYeyJPS6VUW7IBvFF3wv49vvZFzeScPNNxpYmvMW5qASy3kt+qmo0MzYrJPYtL5y0q+b1u/WUOlSA20ZDGL+WQnLn1P0tyW7PFsAyf4XDSP2jFIVEVHC3kCpsj80lCr7GbMFZwlYJlWBmcj9N4Bv2LIDH3y2oNjxLs4O27rWA6XqoQWT8GX9qpik1kXF7d0Ll/46a7jxhvAycWSNhG2zFFRqo+GyflIJqRI93v2ljP0LZFRp70WTO8PPFIns6iLLevVqXgwKchbfGzMV7NkjoW8fDc2aRhadI6skbHtfQemaXrT9m7FZKh/lvfNl7P2f9ZvWDyyS9TxeVdp50eSu6Ppk3RNQvCZKlV1k7a+XUhUfxva3whZIwDkClkrViHHTMXRQHz11gn9uqHgm/4w3Sn+p0ratQzMsw7kUDxbXuh2zXyp860+kN6hbJ/zMjpADIQl1b9DQ9MbgUiXeuFs+tnDWRxwDk1YhdJ2qBkyZeiG9gn/7efnAuImF0zpPPVmA1EjHyXgLN53nHJP0jfJiw3xUl8i0/uum9drXaKj7+yjLh2hs7UseZO8HWjygokJzYzNnUfU7hpspVTFAS5AilCr7A8GZKvsZswVnCVgmVf4neDduUAsDh0/FkAG99TfsIr1B5ywCc637S9XqT1/CzW3LolYe8FGpBzB9RuHSn9jXFCnp3cY3FJzaJumCUKutHHSmSvR05+cyDn4vo2onLxr/MfzszLcLZSxYKKN1Ky96+6VX2LhZxvsfyGhQ34sH7o08w3NsvYyt/5H1JUex9AhjOUKLgbV603ruscJlRSXDi8v/rkIymGPLXLQjl6ZURWaUqHdQquyPDKXKfsZswVkClkmVGIZ/ItAH7+qhHzqc7Gcd+aRKys/DPz96GhO7tMA9KbXx203X46efZHS5XEMPAzMzS0cX5qLqOLIA5asoIaVKzFaJM/ckL9B+WPjZKl96BREbsRn9ktKFszmffq5g5SoJ13fX8JsrI88arX5BwfksCU36qKhyWewzQlvfkXFsgzWb1kWKCZFqoloXDY1uizyGeH3NKFXxIm19O5Qq65kG1kipsp8xW3CWgKVS5exQnGndJ1WeFQtwS85yLK1dBa9XuQZb3miIU6ckPHh/8czmwXqZe0rCynEKlHQvOj+jolRaaKnSZ6s+lXFwsTGh8KVX+O3VGq77Nb2CyGN1+oyEQQMKUL1aeG4ntkjY/JaiLzWKJcdYZql8LYhN66ueL9xs3/xeTc/IHuulb5o/LqH1AFXPpJ4oF6UqUSIRfT8oVdEzi7YEpSpaYrzfbQQoVSYj5pOqgsy/o1H3+lAVGV+n9MWsNzMML/0d3yxhy0wF5Zt40fKhyFIl8kQtH1+YJ6HTCFXPWh7q2rtP0pch9fQKQ1QcOwa8Ms2DUhleDBdLeRGu9f9SII7PadRLRbXO5uVl33cy9nwlI7VcoaSJN/eivc7uk7DuZUWvo+MIc6IXbduR7qdURSKUuJ9TquyPDaXKfsZswVkClkqVb1+VfxqFmtUq66kVunRoWewsPWeHbV3rQqqks6fw3fTH0fe2rmjnqYBHN9+GH3+S9SzlIlt5pMv3dpwv83ikmSpRn0h4KRJf1rhKQ4NbwrfhS69w+x80ZGcDX30t47J2Xtx2S3ipOrVDwsZMRZc2IS+xCFCJsftvWr9OQ90wZyGG4ubbV2ZnpvZIMQv1OaUqVnLOl6NU2R8DSpX9jNmCswQslSrxxl/9OtVx47VdMHnabPTt1V1/EzDY+XrODtu61oVUeebPxciTy/FGh2Z4tFwbeP7dSV/663efivr1Is/uiE3gYjN40z4qKl/mjbj8J3ov8kWtEvmfJODyUSo8pUK3s3adjI8+kfX0CmJf1fYdMu78o4pWLcP3beN0Bae2S6jfU0PN30SWQ6NUfZvWhaS1jzbTuldkl1eQny2h7d8KULqm0Vbjcx+lKj6c7WiFUmUH1eJ1UqrsZ8wWnCVgmVT5H6gsZqf8pSrZUyqkjxuIzjc0x/ZK5TDNcyNWzKiFSy4pfOvPyCXkSKQruGyIioyqxqRK1Lv9QwWHl0uoebWG+jeHl56JzyvIPnfhtb2nhqlITw8tVdn7Jax9SdFlreNTKuRIaReMDNTvnq3vyji2LvpN66d+kbDxdUU/8kbf45VgF6UqwQISRXcoVVHAivFWSlWM4FjMNQTiIlXJPFN1aMNWHJv6V7QedBtSIWPa9nuxeLEHnTtpuMlApnKxaXvJKI9+Pt6VYwv0jeBGlv98s1Viw7aY8RGzVSK9QKhr/gIZCxcV5h2oXcuLhx8MLySbZ8o4sVnWc0qJ3FJWX2JfmOi7vmn9Pg0VWxpr45ePFGQtk1Dneg11rjNWxuq+h6uPUhVP2ta2Ramylmew2ihV9jNmC84SsEyqxDDmzluEJSs3YcSjffHyjI/15b+K5cvoOat69+yWlHuqjkx/CbOzVuLRG7vg2ozaaD/7BpwQS3/3q6hfN/LS3+mdEja8pqBMHS8u/Uuh6BiVKnHvttkKjqyWdPEJl1Tz7FkJk14o3BV+bTcvunUNLVUifYJIoyDeRuw4UoWSas9Dun+hjN3zoti0rgJLn1MgjuwRs2dio3qiXZSqRIuI8f5QqoyzivVOSlWs5FjOLQQslSoxaDErdf9jE4qNf+aLw/UkoMl4He9/K/r/tgXmtqiHx5VOOP1WW/2tvyeHGFuaEqkRRIqE6p01NOxVOPMSjVSJZUOR7Vwsz3V6Kvxs1aq1Mk6e8KJdG6BixdBCsvU9BcfWSqgd40Zyw3FWgdVTZZw/IqNOdw11fhd+5knMnIkZtEvqetHG4IHOhvti0Y2UKotAOlANpcp+6JQq+xmzBWcJWC5Vzg4n/q2fuPNqNHjsDpxKTcFze27DrgWVjB9S7LcvquFtGqp3iV6qxIiLJKi7hroRxCQSoZyjhbmkjCwpRqrLyOdndktY/2phex2GqUgtH1r2fn5PwdG1kv62o3jrMREvSlUiRsVYnyhVxjiZuYtSZYYey7qBgGVS5b9RXbzx538l856qhX/tiW7390BlOR33ftxXf+tPHP0ijoAxcvnOr7v0ERVlfl0ujGamSrRxLkvCGouW67Z/oODwCgk1u2qof1N8xMUnhRVaaGhxf/A2vQXAkr974NWATqNUpFxijK+RGFh5D6XKSprxrYtSZT9vSpX9jNmCswTiIlXJ/Pbf6Fcfx7Odm6KH3Ag1Zl6jJ9kc/kTks/70sHuBxSM9gAp0+UdB0Rt20UqVqGrLv2Uc3yib2sAtNo+vGGcsTYOVj63/pvWW/TSUb1ZSrI6skbBt1oUEqVa2b2VdlCoraca3LkqV/bwpVfYzZgvOEoiLVPk2sD8ztB8y0m3a9ewQx6s3foIfcg7i4cNdoX7VFJ06aOhpcIYn+yCw9kUP0iv/elDxr2OIRar8Z6vETE4sKRB2fCLj0E8yql+hoeEf4jNL5QvbgUUydn0RetP6prcUnNwioUlvFVU6JOYslRgLpcqhL6IFzVKqLIAYoQpKlf2M2YKzBExLlf8hyqGGUqNaJWROGqInAk22K33l68iFigH/9ycUZJXC/feqaGhw6e/wSgnb5yio1NaLZn+6sLE9FqkSXDe/JePEFhn1emgQ2cajufwPahZv1oU7+iaaeo3eK5b11rxQuGld7Aur3f1C/9VzEpY+qwAy0HlMgW1vIxrta7j7KFVWUHSmDkqV/dwpVfYzZgvOEjAtVb7uh9tT5ewQ7W1dWjkNjaQK6Pb27dEt/YmDkT+XcfD7krmgYpWq7AMS1v4ztoSdYpZIzBZV7ehF4zuMvbloNdlQm9bFcTziWJ5Kl2podnd0smh1HyPVR6mKRChxP6dU2R8bSpX9jNmCswQskyojwxBnA057+xM80OdGVChXxkiRhL9HSNUNp1qh9qdXoGMHDbcYXPoTAxPn6onz9Vr2U1G+2YUlrVilStS56Q0FJ7dJeoZ1kWndyCXyPi37hwKvWnhsjFiOdOr6eZaCo2skPRmoSAoqrg2ZCk7vkNDsHg2VWhsbk1P9p1Q5Rd58u5Qq8wwj1UCpikSIn7udAKXKZASFVN2+7HqU31IX992jolED40KydLQCNUdC5zHF80uZkSrfbI9+CPJwFZIn8gD3fC1j3zdyiWXIyCWtv0NsWl81SYaaJ6FVfw2lqnv1s/7kVKDLmAI983wiX5SqRI5O+L5RquyPHaXKfsZswVkClCqT/G9a/X+o8p+uKJOi6Ak/5cKTYCJe4kDklRMUpJQRKQIKit1vRqpERb4ZsIa3aqh+ZfiZHTUPWDG2UO4uG6wio5pxKYw4yBhvOPiDjJ2fyUir4EX1zsDuryRU7aih8R2JPUslhkupijHoCVCMUmV/EChV9jNmC84SoFSZ5P/OR7n6mXqd2mvoGeFQY/+mjm+SseVtGeWbamj5YHFZMCtVp3+RseH1wjfpxKbzcNeBBQp2fSkhXI4ok4hiKi6OyRHH5fguMWtVrjGlKiaYLGSIAKXKECZTN1GqTOFjYRcQoFSZDNKI53Jx5KiM++/R0LCB8T/6e7+WsfcbGbW6aagXcPCyWakSQ1r3LwVn90ho1EtFtc7BZ5/EYcYiL5V486/toypK13J+lsoXDt8ypvg5pbQXnZ5W9cOmE/3iTFWiRyh0/yhV9seOUmU/Y7bgLIGLUqr8zye8tEVDTJvweNiN8y9kzsGbs+bpkQq8/6G/5etv/UWz9Cfq2fxvGSc2ymjWV0WlNsVlxgqpOrlNxqY3CpfQOgwPPlvlO3ewXBMNrR4yLoTxemS3zZFxaruEGlcBtX7rzBuJ0Y6VUhUtscS5n1JlfywoVfYzZgvOErjopErk1Ro5fjrGjuiv582KlJg08PPAn4VUdWyv4ZYolv5EyMV+KrGv6rInVGRUsV6qRBsivYJIsyBSJIhUCf6XeNNvxXgFYmN4qwEqyjVMnFkqZ78S5lqnVJnj52RpSpX99ClV9jNmC84SuOikSkjRrr2HMHhAb518oGQFhkPMUonLd7+Y5ZqSOadodktI1X13q2gUhZSIFAZLxyh61nNxPE3gZcVMlajzxCYJm99WkFbJiw5Diy+fZS2V8MtcRT9vUJw7yMsaApQqazg6UQulyn7qlCr7GbMFZwlcdFIVKEkiaenA4VMxZEBvdGrXvEQ0fBnje1zbWRcrUb5+nero1aOrfu/n83PRvl10S2ciN5V4Q++Sul60CSI0VkmV6N/qKTLOH5bR5C4VVdr9OhvlBVZOLJwpa/GAigrNOUtl1deQUmUVyfjXQ6mynzmlyn7GbMFZAnGVKmeHWth6oBRFkiqRsHT05Bk4dSYbPyxbX2JPVYEanVDps2PfeLH+Aw31fyuh3Z9K5mCQJAmSBGiaedk5sNqLZa9pKFUFuP45Rd/svXepFytnaChTA7huTIInfkqEhyaKPiiyBBE2r9d87KJolrdaQMCjyIjl+2xB0xdNFYIxLxJIZgKWSpVPUNZv3lGCmZEN4fEAHe1MVaCEieXDOZ8tKFr+O3wyN+pub50lI2sl0OR2L2pcUfKPb0aqjBSPgtPn8qOuu0QBL7B8soTzhyW0uEdDlTbA8okSzh+V0PJeLyoHbJI33+DFXUO50inIyS1AbgGlym1PQtXyaYjl++y2cTrZX8GYFwkkMwFLpSpQWBIRXDR7qnyzVHf07Fa0NBi4B+vAsfNRD3Ptix5kHwQu/YuKMnVK/vG1cvlPdO7YOglb31WQUVVDvRuALe/ISK/kRfth3EsVdfAiFODyn9VE41cfl//sZ83lP/sZswVnCVgmVW45UDnS23+BM1FCFA8dPo5nhvZDRnqq/rag/0xVLFK1+MnCs2PEJnWxWT3wslqqRP2rn5dx/ogMJcMLsVG+6Z0aKrePfunS2cc18VunVCV+jEL1kFJlf+woVfYzZgvOErjopErgDpenKlCafLNVX8xfokcqcBkzWqnK3g+sfcmDjKpeXDYk+EyRHVJ1eJWE7e8X7p/Sc1c96Y5kms5+PaJvnVIVPbNEKUGpsj8SlCr7GbMFZwlYJlViGIH7j5wdWnxaj1aqDq+Qsf0DGZXbaWh6V/CZIjukStBYOUlB7jEJjW/XUPVyzlLZ8YRQquygGp86KVX2c6ZU2c+YLThLwFKpEktr7879BkMH9tGXyi6GK1qp2vmpDJHJvF4PDbV+G1+puhji4fQYKVVORyD29ilVsbMzWpJSZZQU73MrAcukKtybfwJOorz9Z3WgopWqDa8pOL1TQsuHVJRvEvwNMbtmqqweO+srSYBS5d6nglJlf+woVfYzZgvOErBMqpwdhnOtRytVS0Z5IA4y7jxG1TeNB7soVc7F02zLlCqzBJ0rT6mynz2lyn7GbMFZApQqk/yjkaqcoxJWTVaQWsaLjqNCpzOgVJkMioPFKVUOwjfZNKXKJEADxSlVBiDxFlcToFSZDF80UnVsvYyt/5H1Y2HE8TChLkqVyaA4WJxS5SB8k01TqkwCNFCcUmUAEm9xNQFLpcp3Tt7BrGMloHBPFbDnfzL2zZdR+xoNdX8f+u07SpV7v1OUKvfGjlJlf+woVfYzZgvOErBMqnz5nLp0aIm2rRoXewtQpFq4unOboAcWOzt8861HM1O1+S0ZJ7bIaNpXDXs8DKXKfFycqoFS5RR58+1SqswzjFQDpSoSIX7udgKWSZV/RnUBZfKrszH+qf6oUK6Mnmzzg88WFGUldzs0//5HI1UrxirIOy3hsqEqMiqHPhuOUuXeJ4RS5d7YUarsjx2lyn7GbMFZArZIVcXyZTD+pXcx4tG+ulSJZUF/yXJ2yNa2blSqxNEwS8co+rE04niacBelytoYxbM2SlU8aVvbFqXKWp7BaqNU2c+YLThLwDKp8l/+69Wja7Hs6uLolyUrN13UM1WntknY+IaCMvW9uHRg+IOMKVXOfinMtE6pMkPP2bKUKvv5U6rsZ8wWnCVgmVQFDsM/GWiNapWQOWkIGtWr6exobWjd6EzVgUUydn0ho/oVGhr+IfwRMZQqGwIVpyopVXECbUMzlCoboAZUSamynzFbcJaAbVLl7LDi17pRqfp5loKjayQ0ul1FtctD76cSPadUxS9+VrdEqbKaaPzqo1TZz5pSZT9jtuAsAUqVSf5GpWr1FAXnD0to81cVl9SmVJnEnrDFKVUJG5qIHaNURURk+gZKlWmErCDBCVgqVb59VV/MXwLfkl/NapUxevIMiFQLYq9Vsl2GpEoFFo/06EO/cmwBoISnwJkq9z4llCr3xo5SZX/sKFX2M2YLzhKwVKpEPqr6darjxmu7YPK02ejbq7u+j+piT6lwdq+Eda8oKFUNaDc4/Jt/XP5z9gthtnVKlVmCzpWnVNnPnlJlP2O24CwBy6TKP0+VmJ3yl6qLPaXCoSUSdnysoMplXjTpE/7NP0qVs18Is61TqswSdK48pcp+9pQq+xmzBWcJxEWqLvaZql8+lpG1REb9Hhpq/jb8m3+UKme/EGZbp1SZJehceUqV/ewpVfYzZgvOErBMqsQwfPmoRNLPl2d8rC//iUSgA4dPRe+e3S7aPVXr/qXg7B4JrfqrKNc4/CZ1SpWzXwizrVOqzBJ0rjylyn72lCr7GbMFZwlYKlViKGJW6v7HJhQb1cwXhyfluX9ikEY2qi8Z5YGWD3Qeo0LJoFQ5+8jb2zqlyl6+dtZOqbKTbmHdlCr7GbMFZwlYLlXODif+rUeSqvNHJKx+XkFqOS86PhV5PxVnquIfQytbpFRZSTO+dVGq7OdNqbKfMVtwlgClyiT/SFJ1dK2En99TUKG5hhYPRN5PRakyGRCHi1OqHA6AieYpVSbgGSxKqTIIire5lgClymToIknV7i9l7F8go/Z1GupeT6kyiTvhi1OqEj5EITtIqbI/dpQq+xmzBWcJWCpks4dwAAAYGklEQVRVInXCgGFTcDDrWIlRXdqiIaZNeBwVypVxdsQWtx5JqjbNUHByq4Rm92io1JpSZTH+hKuOUpVwITHcIUqVYVQx30ipihkdC7qEgGVS5cumnqyZ00PFM5JULX9OQf5ZCe2HqUivFHmTOpf/XPLNCdFNSpV740epsj92lCr7GbMFZwlYJlX+yT9FFnUnL9EXkcZh/eYdejfCvX0Yanbtpuu64Jmh/ZCRngqRKf7NWfP0ugJn3MJJVd5pYMVYD+QUoMs/ImdS9zHjMTVOPj3m2qZUmePnZGlKlf30KVX2M2YLzhKwTKp8M1V39OzmaPqEwBkzIU0jx0/H2BH99SNzjFy+43bEWYW+3Fs+wQr8OZxUndgqYfMMBWUbeNH6z8be/ONMlZEIJe49lKrEjU2knlGqIhEy/zmlyjxD1pDYBCyTKjHMQOFwYuiBR+JEuywZWF4IlrgGD+it/3+Rh2tK5pyi/WHhpGrfdzL2fCWjxpUaGtxqbD8VpcqJp8a6NilV1rGMd02UKvuJU6rsZ8wWnCVgqVQlwkb1QOkReAPFKBxy/1kqcZ9vTD2u7ayLVeDn4aRq67sKjq2T0PiPKqp2MrafilLl7BfCbOuUKrMEnStPqbKfPaXKfsZswVkClklVtDNCdg072DmDRqUq2MHPvnGdOpONH5atL7GnKjc/9LLet2M0ZGcBXUdIKFdXMjxkWZYgSxIKVOOzW4Yr5422EkhRZKiaF5rXuETb2iFWbphAWoqCcN9nwxXxxpAEBGNeJJDMBCyTqkTZqB7rTFUoKQycmRJLnHM+W1C0/HfsdF7Q50McS7PwSQmQgG6TvJCi+LckPUWGxyPj7Hnjm9uT+SF109jKlPIgN09FXgGlyk1xE32tVDYVob7PbhtLovZXMOZFAslMwDKpSpSN6rHuqQomY8HGFLjxPdTy35ndEta/qqB0DaDtY9HJEd/+c+9Xjst/7o0dl//sjx2X/+xnzBacJWCZVIlhJMJG9Uhv//n2SI0f0b/oLcVwS5dipurQ4eNF6RUCZ6pCSdWhn2Ts+ERGlfZeNLnT+Jt/giOlytkvhZnWKVVm6DlbllJlP39Klf2M2YKzBCyTqsDcUIHDimdG9XB5qoJJVTgZ9AnXF/OX6EMymqfql48UZC2TUP9mDTWvjm5vFKXK2S+FmdYpVWboOVuWUmU/f0qV/YzZgrMELJMqZ4fhXOuhZqrWvazg7D4JrR5WUa5RdPtrKFXOxdNsy5QqswSdK0+psp89pcp+xmzBWQKUKpP8g0qVF1g80gOoQOcxKpQMSpVJzK4pTqlyTahKdJRSZX/sKFX2M2YLzhKgVJnkH0yqzmUBa17wILW8Fx1HRLefSnSHM1Umg+JgcUqVg/BNNk2pMgnQQHFKlQFIvMXVBChVJsMXTKqOrJawbbaCCi00tLg/uv1UlCqTAXG4OKXK4QCYaJ5SZQKewaKUKoOgeJtrCVCqTIYumFTt+kLGgUUy6nTXUOd3lCqTiF1VnFLlqnAV6yylyv7YUarsZ8wWnCVAqTLJP5hUbZyu4NR2Cc3v1VCxFaXKJGJXFadUuSpclKo4h4tSFWfgbC7uBChVJpEHk6qloxWoORI6PKkirWJ0m9S5/GcyIA4Xp1Q5HAATzXOmygQ8g0UpVQZB8TbXEqBUmQxdoFTlnpKwcpwCOQXo8o/oMqn7usKN6iaD4mBxSpWD8E02TakyCdBAcUqVAUi8xdUEKFUmwxcoVSc2Sdj8toKyDb1oPSD6N/84U2UyIA4Xp1Q5HAATzVOqTMAzWJRSZRAUb3MtAUqVydAFStW++TL2/E9Gjd9oaNAz+v1UlCqTAXG4OKXK4QCYaJ5SZQKewaKUKoOgeJtrCVCqTIYuUKq2viPj2AYZje9QUbVj9PupKFUmA+JwcUqVwwEw0TylygQ8g0UpVQZB8TbXEqBUmQxdoFStmqgg57iEto8WoHSt2CrnnqrYuCVCKUpVIkQhtj5QqmLjFk0pSlU0tHivGwlQqkxGzV+qtHxgySgPoABXji0ApNgqp1TFxi0RSlGqEiEKsfWBUhUbt2hKUaqiocV73UiAUmUyav5SdXqHhA2ZCkrVBNr9LbY3/0R3KFUmg+JgcUqVg/BNNk2pMgnQQHFKlQFIvMXVBChVJsPnL1UHf5Sx878yqnTwoknv2N78o1SZDIjDxSlVDgfARPOUKhPwDBalVBkExdtcS4BSZTJ0/lK1/QMFh1dIqN9TQ83fxPbmH6XKZEAcLk6pcjgAJpqnVJmAZ7AopcogKN7mWgKUKpOh85eqtS95kL0faPWwinKNYnvzj1JlMiAOF6dUORwAE81TqkzAM1iUUmUQFG9zLQFKlcnQFUmVF1g80gOohZnURUb1WC/uqYqVnPPlKFXOxyDWHlCqYiVnvBylyjgr3ulOApQqk3HzSVX2QWDtix6kVfCiw/DY91NxpspkQBwuTqlyOAAmmqdUmYBnsCilyiAo3uZaApQqk6HzSdWRlRK2zVFQsZWG5vfGvp+KUmUyIA4Xp1Q5HAATzVOqTMAzWJRSZRAUb3MtAUqVydD5pGrXZzIO/CCjzu801OlOqTKJ1bXFKVWuDR0oVfbHjlJlP2O24CwBSpVJ/j6p2pip4NQOCc3v01CxJaXKJFbXFqdUuTZ0lKo4hI5SFQfIbMJRApQqk/h9UrV0tAI1R9L3U4l9VWYublQ3Q8/ZspQqZ/mbaZ0zVWboGStLqTLGiXe5lwClymTshFTlHpewcqICJd2Lzs+Y26QuukOpMhkUB4tTqhyEb7JpSpVJgAaKU6oMQOItriZAqTIZPiFVxzfK2PJvGeUaetFqAKXKJFJXF6dUuTd8lCr7Y0epsp8xW3CWQFJK1YlTZzBw+FSs37xDpzvzxeHo1K55UNK/7D6AAcOm4GDWsWKf33RdFzwztB8y0lNxPicPoyfPwBfzl+j3PDesH3r16Kr/byFVe7+WsfcbGTWu1tDgZnP7qThT5ewXwmzrlCqzBJ0rT6mynz2lyn7GbMFZAkknVT4B6tKhpS4+QppGjp+OsSP6o1G9moZov5A5B/XrVNfLB9YXWIGQqi1vyzi+SUbj3iqqdjC3n4pSZShECXsTpSphQxOxY5SqiIhM30CpMo2QFSQ4gaSTKiFRk1+djfFP9UeFcmUiSlFgfALLz523CLv2HsLgAb2DhlJI1YrxCvJOSmj7WAFK1zAfce6pMs/QqRooVU6RN98upco8w0g1UKoiEeLnbieQdFK1fM0WTMmcg2kTHtelSlxi5klcocTIP4j+s1S+sm/Omld0S41qlZA5aUjRrNfefTlYOkYBFODKsQWAZP6RoFSZZ+hUDZQqp8ibb5dSZZ5hpBooVZEI8XO3E0hKqfrgswVF+6GikapQs1x39OxWtCdLzFzN+WxBkbTtXV+Apf/0omwdCb8Zbs3j4JElyLKMvALzm96t6RFrMUogzaOgQNWges0vAxttk/dZQ6BUmgfncgusqYy1BCUgGPMigWQmkJRSFctMVbC9U77f+UuVbxP8kAG9ddFa90U+fv4YqNkFaHmXNY9KqkeGR5H5D7w1OONaS+l0D/LyVeSrlKq4gregsfKlU3AyO9+CmlhFKAKCMS8SSGYCSSdVse6pCrZs6Jvl8m1aFz8LqRoxbjqGDuqjLwEufDUPR1ZJaHCLhhpXmX/zT7TB5T/3fuW4/Ofe2HH5z/7YcfnPfsZswVkCSSdVkd7+86VQGD+if9GSXrg3/IRsjRg/vWgflVj+W7JyU9Hy4rxR+Th3CGg9QEXZhtbMTlCqnP1SmGmdUmWGnrNlKVX286dU2c+YLThLIOmkyjebFCpPVTCpChSlwJCIz5+eNEP/9aUtGhbbBP/hQ4XLBZ2fK4CSak0wKVXWcHSiFkqVE9StaZNSZQ3HcLVQquxnzBacJZCUUhVPpEKq0it50X6YdZvKKVXxjKC1bVGqrOUZz9ooVfbTplTZz5gtOEuAUmWSv5CqSq01NLvHmv1UojuUKpNBcbA4pcpB+CabplSZBGigOKXKACTe4moClCqT4RNSVfd6DbWvo1SZRJkUxSlV7g0jpcr+2FGq7GfMFpwlQKkyyV9IVYv7VFRoac0mdc5UmQyIw8UpVQ4HwETzlCoT8AwWpVQZBMXbXEuAUmUydEKqOj6lIrUcpcokyqQoTqlybxgpVfbHjlJlP2O24CwBSpVJ/ju25yC9gnVCxZkqkwFxuDilyuEAmGieUmUCnsGilCqDoHibawlQqkyGThyobPXFjepWE41ffZSq+LG2uiVKldVES9ZHqbKfMVtwlgClyiR/SpVJgElWnFLl3oBSquyPHaXKfsZswVkClCqT/ClVJgEmWXFKlXsDSqmyP3aUKvsZswVnCVCqTPKnVJkEmGTFKVXuDSilyv7YUarsZ8wWnCVAqTLJn1JlEmCSFadUuTeglCr7Y0epsp8xW3CWAKXKJH9KlUmASVacUuXegFKq7I8dpcp+xmzBWQKUKpP8KVUmASZZcUqVewNKqbI/dpQq+xmzBWcJUKpM8qdUmQSYZMUpVe4NKKXK/thRquxnzBacJUCpMsmfUmUSYJIVp1S5N6CUKvtjR6mynzFbcJYApcokf0qVSYBJVpxS5d6AUqrsjx2lyn7GbMFZApQqZ/mzdRIgARIgARIggSQhQKlKkkByGCRAAiRAAiRAAs4SoFQ5y5+tkwAJkAAJkAAJJAkBSlWSBJLDIAESIAESIAEScJYApcpZ/sVa/2X3AQwYNgUHs44V/f7SFg0xbcLjqFCuTAL1lF3xERAxm/zqbIx/qn+xGJ04dQYDh0/F+s079Ftnvjgcndo1J7gEIvBC5hzUr1MdvXp0LepVYNzEBzWqVULmpCFoVK9mAvWeXSEBEkhEApSqBIqK+AM9cvx0jB3Rn/+AJ1BcgnXF/49voPiez8nD6Mkz0KVDS/0PNuOaWMGcO28Rnp40Q+/Uc8P6BZWqIQN6U4ITK2zsDQm4ggClKoHCxD++CRQMg10JNlMV+LtAyTJYNW+zmUC4mSpKlc3wWT0JJCkBSlUCBTZw+Y9LfwkUnBBdCSZVy9dswZTMOcWWbcUfcHENHtA78Qd1kfTQyPIfl/4ukoeBwyQBiwhQqiwCaUc14h/9Q4eP45mh/ZCRnmpHE6zTJIFQUvXBZwuKxY1SZRK0DcWDSVVgM2KpcM5nC7iv0Qb+rJIEkpEApSqBoxpqE3QCd/mi6xpnqtwbciNSJfbOjRg3HUMH9eE+R/eGmj0ngbgRoFTFDXX0DVGqomcW7xLcUxVv4ta1R6myjiVrIgESKCRAqUqgJ+H/FixD4wa1i/6LmEtGCRScEF0JJlV8+y/x4yZ6GEyqxH44cfnSX4jlvyUrN3EJ3h0hZS9JwHEClCrHQ3ChA+If9Psfm1D0i5uu68J/zBMoPv5dCZbP6MG7ehRtRGeeqgQNHAD/lAqil/6b0fmySOLGjT0jATcQoFS5IUrsIwmQAAmQAAmQQMIToFQlfIjYQRIgARIgARIgATcQoFS5IUrsIwmQAAmQAAmQQMIToFQlfIjYQRIgARIgARIgATcQoFS5IUrsIwmQAAmQAAmQQMIToFQlfIjYQRIgARIgARIgATcQoFS5IUrsIwmQAAmQAAmQQMIToFQlfIjYQRIgARIgARIgATcQoFS5IUrsIwmQAAmQAAmQQMIToFQlfIjYQRIgARIgARIgATcQoFS5IUrsIwmQAAmQAAmQQMIToFQlfIjYQRIgARIgARIgATcQoFS5IUrsIwmQAAmQAAmQQMIToFQlfIjYQRIgARIgARIgATcQoFS5IUrsIwmQAAmQAAmQQMIToFQlfIjYQRIgARIgARIgATcQoFS5IUrsIwm4iMD5nDyMnjwDXTq0RK8eXYP2/MSpMxg4fCqGDOiNTu2au2h07CoJkAAJhCZAqeLTQQIkEJbA8jVbMGL8dGROGoJG9WpGpEWpioiIN5AACSQpAUpVkgaWwyIBpwhQqpwiz3ZJgAScJkCpcjoCbN8UAd8y0qD7bsXnX/+EL+Yv0et7bli/oqUn3z3rN+8oauvBu3pg8IDe+s/B6rjpui547OE7MHjMvxCqnE8e2rRshHWbfilqW9T9QJ8b9eUtX1n//hgZsJgdmpI5R18eE7NEB7OO6cVmvjg8quWyufMWYcnKTbj5d1fo/RFXjWqVSsw6ifuenjSjqGv+7fj6Mm3C46hQrox+zy+7D2DAsClF/RK/E8yeGdpP/9y3/Ldr7yG8OWue/jvf5xnpqUXMH7jz93jr/a9Ccgpsxz9u/vLma+fSFg0h+nn85Jli/Qs2ZiNx4D0kQAIkEA0BSlU0tHhvwhHwCdHR46eKRMH3h3j8iP66gIh73pr9JQbe9wf4/0Hv3bObLl7B6vDJVrhyvj/qqzZsK9G2KO9bLhP9GTl+OsaO6G9o+UyUFSJz/2MTiomIEJ85ny3QpcEnN5EC4pMlfxl5IXMODh0+rguQ4OETL9/PgfwCpSrwc9EH/zp8UiUE1ydnPsaBzMW9vvEE1hv4s4939aoVdSH2/ezfjr8k++/XEmPYe+BwyD1ekTjycxIgARIwQoBSZYQS70lYAqE2PAtxEJdvNipwAEICxOyG+DyaTdP+5YItcxn9XSSgoWaHopWzQGHyCZuYBRMyI64R46Zj6KA+xYTPn19gX4KxDSZVgRvV/csZiVukvqenpQXdEB+LxEaKBz8nARIgASMEKFVGKPGehCUQ6o9zqNkX3zKaGJBvOSonNzfkm2hGl7l8b7m5TaoCl8n8A+2b3fKXqlAiY5VU+dcz7e1PUL9O9WKzSyLePgmsWa1yUKnyn8ES44l26TVhH3Z2jARIIOEJUKoSPkTsYDgCRqTqy2+X6PuF/PcJ+f/xDiVVvqWzUOVEvwJTB7hRqiLNfgWTqjt6diu2tyuRpMr3vFCu+G8HCZBAvAlQquJNnO1ZSsDIMpJYdgqc8TAiVZHKJYNUiTFEyhcVz5kq/yXCWJf/gj1gkZaDLX0oWRkJkMBFS4BSddGGPjkGHkyqAvMqBW7M9i3ptW/dRN+sHWqmKlK5ZJAqseFdjHPet0uLvRHov7E7cE9V4IZ5Xwzq1qxa4u0//+SfkfZUBcbN6Eb1wL1bop7vl64r2k9nJMVDcnwbOAoSIAGnCVCqnI4A2zdFIFi6hMDX5wOXgcReKl8ahHBSFalcskiVGEdgSgV/hsE2zfvfL9IYXHvVZdi+c3/UUuWfriJY2gOjKRX85S1SCg1TDxwLkwAJkEAYApQqPh6uJhDNm3uuHmiCd97/rcgE7yq7RwIkQAK2EaBU2YaWFceDgNukKnBGKBgjI2+riaU0X1LNUJyjTRRqNF5i9mj+9yvx8N099SJui4HRcfI+EiABEoiWAKUqWmK8P6EI8A96/MMRLM2EXQIX/9GxRRIgARKInQClKnZ2LEkCJEACJEACJEACRQQoVXwYSIAESIAESIAESMACApQqCyCyChIgARIgARIgARKgVPEZIAESIAESIAESIAELCFCqLIDIKkiABEiABEiABEiAUsVngARIgARIgARIgAQsIECpsgAiqyABEiABEiABEiABShWfARIgARIgARIgARKwgAClygKIrIIESIAESIAESIAEKFV8BkiABEiABEiABEjAAgKUKgsgsgoSIAESIAESIAESoFTxGSABEiABEiABEiABCwhQqiyAyCpIgARIgARIgARIgFLFZ4AESIAESIAESIAELCBAqbIAIqsgARIgARIgARIgAUoVnwESIAESIAESIAESsIAApcoCiKyCBEiABEiABEiABChVfAZIgARIgARIgARIwAIClCoLILIKEiABEiABEiABEqBU8RkgARIgARIgARIgAQsIUKosgMgqSIAESIAESIAESIBSxWeABEiABEiABEiABCwgQKmyACKrIAESIAESIAESIAFKFZ8BEiABEiABEiABErCAAKXKAoisggRIgARIgARIgAQoVXwGSIAESIAESIAESMACApQqCyCyChIgARIgARIgARKgVPEZIAESIAESIAESIAELCFCqLIDIKkiABEiABEiABEiAUsVngARIgARIgARIgAQsIECpsgAiqyABEiABEiABEiABShWfARIgARIgARIgARKwgAClygKIrIIESIAESIAESIAEKFV8BkiABEiABEiABEjAAgKUKgsgsgoSIAESIAESIAESoFTxGSABEiABEiABEiABCwhQqiyAyCpIgARIgARIgARI4P8BsPn6lw1xY2YAAAAASUVORK5CYII=",
+      "text/html": [
+       "<div>                            <div id=\"8e731f5c-5a0a-40b5-9a4a-6ed8b2dbef01\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                require([\"plotly\"], function(Plotly) {                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"8e731f5c-5a0a-40b5-9a4a-6ed8b2dbef01\")) {                    Plotly.newPlot(                        \"8e731f5c-5a0a-40b5-9a4a-6ed8b2dbef01\",                        [{\"hovertemplate\":\"param_hybrid_weights=(1, 0, 0, 0, 0)\\u003cbr\\u003eparam_n_neighbors=%{x}\\u003cbr\\u003emean_test_score=%{y}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"legendgroup\":\"(1, 0, 0, 0, 0)\",\"line\":{\"color\":\"#636efa\",\"dash\":\"solid\"},\"marker\":{\"symbol\":\"circle\"},\"mode\":\"lines\",\"name\":\"(1, 0, 0, 0, 0)\",\"orientation\":\"v\",\"showlegend\":true,\"x\":[4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19],\"xaxis\":\"x\",\"y\":[0.8008378078301959,0.8400062445502972,0.8096721096361099,0.8559125351204843,0.8336324358130058,0.8527611277611278,0.8366577903898239,0.8614862699888679,0.8543397891689771,0.8646500028077732,0.8579139153827342,0.8649543378995436,0.8570850413953863,0.8684907085177009,0.8638235448485803,0.870748299319728],\"yaxis\":\"y\",\"type\":\"scatter\"},{\"hovertemplate\":\"param_hybrid_weights=(1, 1, 1, 1, 1)\\u003cbr\\u003eparam_n_neighbors=%{x}\\u003cbr\\u003emean_test_score=%{y}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"legendgroup\":\"(1, 1, 1, 1, 1)\",\"line\":{\"color\":\"#EF553B\",\"dash\":\"solid\"},\"marker\":{\"symbol\":\"circle\"},\"mode\":\"lines\",\"name\":\"(1, 1, 1, 1, 1)\",\"orientation\":\"v\",\"showlegend\":true,\"x\":[4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19],\"xaxis\":\"x\",\"y\":[0.8075935453622654,0.8430578785922963,0.8186283695823878,0.8460811690308093,0.8401247232523816,0.8613621686330353,0.8420278333481293,0.860641288478862,0.8498768836797005,0.8614241048332417,0.8543264207057311,0.867633122214403,0.8680721392635153,0.8692013791818098,0.8692013791818098,0.8692013791818098],\"yaxis\":\"y\",\"type\":\"scatter\"},{\"hovertemplate\":\"param_hybrid_weights=(3, 1, 1, 1, 1)\\u003cbr\\u003eparam_n_neighbors=%{x}\\u003cbr\\u003emean_test_score=%{y}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"legendgroup\":\"(3, 1, 1, 1, 1)\",\"line\":{\"color\":\"#00cc96\",\"dash\":\"solid\"},\"marker\":{\"symbol\":\"circle\"},\"mode\":\"lines\",\"name\":\"(3, 1, 1, 1, 1)\",\"orientation\":\"v\",\"showlegend\":true,\"x\":[4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19],\"xaxis\":\"x\",\"y\":[0.8042368616580481,0.8524093598806555,0.8216261310206399,0.848984918136226,0.8427930652715798,0.8622252963759347,0.854621049850091,0.8638022080190918,0.8519063391000493,0.86297102497116,0.8578221153148611,0.8657296456608151,0.8653682852451325,0.867633122214403,0.8688259281038822,0.8692013791818098],\"yaxis\":\"y\",\"type\":\"scatter\"},{\"hovertemplate\":\"param_hybrid_weights=(1,)\\u003cbr\\u003eparam_n_neighbors=%{x}\\u003cbr\\u003emean_test_score=%{y}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"legendgroup\":\"(1,)\",\"line\":{\"color\":\"#ab63fa\",\"dash\":\"solid\"},\"marker\":{\"symbol\":\"circle\"},\"mode\":\"lines\",\"name\":\"(1,)\",\"orientation\":\"v\",\"showlegend\":true,\"x\":[4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19],\"xaxis\":\"x\",\"y\":[0.7546531749844266,0.8236489483815183,0.7971094199066515,0.8240579332078364,0.802456834960865,0.8394657957400525,0.8231423720288751,0.8521637096606087,0.8431410284217963,0.861854780372371,0.8534741237538748,0.860362294426858,0.8563573621610562,0.8654881749426915,0.8587845852444392,0.8677751535191309],\"yaxis\":\"y\",\"type\":\"scatter\"}],                        {\"template\":{\"data\":{\"histogram2dcontour\":[{\"type\":\"histogram2dcontour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"choropleth\":[{\"type\":\"choropleth\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"histogram2d\":[{\"type\":\"histogram2d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmap\":[{\"type\":\"heatmap\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmapgl\":[{\"type\":\"heatmapgl\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"contourcarpet\":[{\"type\":\"contourcarpet\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"contour\":[{\"type\":\"contour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"surface\":[{\"type\":\"surface\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"mesh3d\":[{\"type\":\"mesh3d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"parcoords\":[{\"type\":\"parcoords\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolargl\":[{\"type\":\"scatterpolargl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"scattergeo\":[{\"type\":\"scattergeo\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolar\":[{\"type\":\"scatterpolar\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"scattergl\":[{\"type\":\"scattergl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatter3d\":[{\"type\":\"scatter3d\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattermapbox\":[{\"type\":\"scattermapbox\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterternary\":[{\"type\":\"scatterternary\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattercarpet\":[{\"type\":\"scattercarpet\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}]},\"layout\":{\"autotypenumbers\":\"strict\",\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"hovermode\":\"closest\",\"hoverlabel\":{\"align\":\"left\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"bgcolor\":\"#E5ECF6\",\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"ternary\":{\"bgcolor\":\"#E5ECF6\",\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]]},\"xaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"yaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"geo\":{\"bgcolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"subunitcolor\":\"white\",\"showland\":true,\"showlakes\":true,\"lakecolor\":\"white\"},\"title\":{\"x\":0.05},\"mapbox\":{\"style\":\"light\"}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"param_n_neighbors\"}},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"mean_test_score\"}},\"legend\":{\"title\":{\"text\":\"param_hybrid_weights\"},\"tracegroupgap\":0},\"margin\":{\"t\":60}},                        {\"responsive\": true}                    ).then(function(){\n",
+       "                            \n",
+       "var gd = document.getElementById('8e731f5c-5a0a-40b5-9a4a-6ed8b2dbef01');\n",
+       "var x = new MutationObserver(function (mutations, observer) {{\n",
+       "        var display = window.getComputedStyle(gd).display;\n",
+       "        if (!display || display === 'none') {{\n",
+       "            console.log([gd, 'removed!']);\n",
+       "            Plotly.purge(gd);\n",
+       "            observer.disconnect();\n",
+       "        }}\n",
+       "}});\n",
+       "\n",
+       "// Listen for the removal of the full notebook cells\n",
+       "var notebookContainer = gd.closest('#notebook-container');\n",
+       "if (notebookContainer) {{\n",
+       "    x.observe(notebookContainer, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "// Listen for the clearing of the current output cell\n",
+       "var outputEl = gd.closest('.output');\n",
+       "if (outputEl) {{\n",
+       "    x.observe(outputEl, {childList: true});\n",
+       "}}\n",
+       "\n",
+       "                        })                };                });            </script>        </div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.3s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.1s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.3s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=7, slices=[slice(0, None, None)]; total time=   1.0s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   1.1s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=16, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=12, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=12, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.6s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=12, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.1s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.6s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=16, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=16, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=5, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=10, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.6s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.6s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=5, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=10, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=16, slices=[slice(0, None, None)]; total time=   1.0s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.6s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=12, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.6s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.3s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=5, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.6s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=10, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=16, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=5, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.6s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.6s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=16, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.3s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.3s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   1.1s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.1s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=1, slices=[slice(0, None, None)]; total time=   1.0s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   1.0s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.6s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.3s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.6s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=10, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=10, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=10, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=16, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.3s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=5, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=8, slices=[slice(0, None, None)]; total time=   1.0s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   1.0s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.6s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.6s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=2, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=16, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.0s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.3s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=7, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=6, slices=[slice(0, None, None)]; total time=   1.0s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=12, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=12, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=18, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=3, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=12, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=11, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.3s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=1, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=14, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=6, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=10, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   1.1s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=5, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=12, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=17, slices=[slice(0, None, None)]; total time=   0.9s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=4, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=11, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=2, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=7, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.6s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 0, 0, 0, 0), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=euclidean, n_neighbors=16, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=3, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=8, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=13, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1, 1, 1, 1, 1), metric=jaccard, n_neighbors=19, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=euclidean, n_neighbors=17, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=5, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=9, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(3, 1, 1, 1, 1), metric=jaccard, n_neighbors=15, slices=[slice(0, 2048, None), slice(2048, 3678, None), slice(3678, 4227, None), slice(4227, 4806, None), slice(4806, 5740, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=1, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=10, slices=[slice(0, None, None)]; total time=   0.6s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=15, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=4, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=9, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=13, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.2s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=12, slices=[slice(0, None, None)]; total time=   0.8s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=18, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=euclidean, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.1s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=6, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=10, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=16, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=8, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=14, slices=[slice(0, None, None)]; total time=   0.7s\n",
+      "[CV] END hybrid_weights=(1,), metric=jaccard, n_neighbors=19, slices=[slice(0, None, None)]; total time=   0.7s\n"
+     ]
+    }
+   ],
+   "source": [
+    "import plotly.express as px\n",
+    "pdf = pd.DataFrame(best.cv_results_)\n",
+    "fig_df = pdf.copy()\n",
+    "rm_idx = []\n",
+    "rm_idx += list(fig_df[fig_df['param_n_neighbors'] <= 3].index)\n",
+    "rm_idx += list(fig_df[fig_df['param_metric'] == 'euclidean'].index)\n",
+    "\n",
+    "fig_df = fig_df.drop(list(rm_idx))\n",
+    "fig = px.line(fig_df, x=\"param_n_neighbors\", y=\"mean_test_score\", color='param_hybrid_weights')\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eeaeae77-1e0e-489e-843d-37624319cade",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/misc/example_j_index_error.ipynb
+++ b/notebooks/misc/example_j_index_error.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "## The problem:\n",
     "\n",
-    "In `GenRAPredValue.predict(...)` method, `denom=np.sum(neigh_sim[j])` takes the sum of similarities across all neighbors for query point `j`. However, `j` represents the index of outputs - i.e., `j` will be within `range(n_outputs)` - and shouldn't be used as index to identify a query point. \n",
+    "In `GenRAPredValue.predict(...)` method, `denom=np.sum(neigh_sim[j])` takes the sum of similarities across all neighbors for query point `j`. However, `j` represents the index of outputs - i.e., `j` will be within `range(n_outputs)` - and shouldn't be used as index to identify a query point. There exists another instance of this issue in line `num = np.sum(_y[neigh_ind, j] * neigh_sim[j], axis=1)`.\n",
     "\n",
     "Issues:\n",
     "- If `n_outputs==1` (which it may often be), but `n_queries>1`, the prediction for all query points not in index=0 were likely miscalculated, since the wrong denominator was used\n",
@@ -22,9 +22,12 @@
    "source": [
     "## The proposed solution\n",
     "\n",
-    "Setting `denom=np.sum(neigh_sim, axis=1)` outside the forloop.\n",
+    "Setting `denom=np.sum(neigh_sim, axis=1)` outside the forloop, and then adjusting numerator to `num = np.sum(_y[neigh_ind, j] * neigh_sim, axis=1)`. \n",
     "\n",
-    "Note that `denom` is now an array of floats (as opposed to a float). Since `denom.shape == num.shape` (more specifically `shape=(n_queries,)`), the operation `num / denom` becomes an element wise operation where numerator is still the regressand and the numerator is each query point's respective sum of similarities."
+    "Note that `denom` is now an array of floats; it has shape `(n_queries,)`.\n",
+    "And `num` is now corrected to sum for each query point. \n",
+    "\n",
+    "Since `denom.shape == num.shape` (more specifically `shape=(n_queries,)`), the operation `num / denom` becomes an element wise division operation. Numerator is the regressand for each query point, and the numerator is the sum of similarities for each query point."
    ]
   },
   {
@@ -975,6 +978,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "e3c501a1-d44e-40af-a5bd-c0f18003f02c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
    "execution_count": 18,
    "id": "31b0c034-9d62-474f-89a0-54aa768498bd",
    "metadata": {},
@@ -1002,6 +1013,7 @@
    ],
    "source": [
     "# this will error out\n",
+    "\n",
     "genra_model.predict(query_X)"
    ]
   }

--- a/src/genra/rax/skl/reg.py
+++ b/src/genra/rax/skl/reg.py
@@ -139,8 +139,8 @@ class GenRAPredValue(KNeighborsRegressor):
 
         y_pred = np.empty((X.shape[0], _y.shape[1]), dtype=np.float64)
 
+        denom=np.sum(neigh_sim, axis=1)
         for j in range(_y.shape[1]):
-            denom=np.sum(neigh_sim[j])
             num = np.sum(_y[neigh_ind, j] * neigh_sim[j], axis=1)
             y_pred[:, j] = num / denom
 

--- a/src/genra/rax/skl/reg.py
+++ b/src/genra/rax/skl/reg.py
@@ -141,7 +141,7 @@ class GenRAPredValue(KNeighborsRegressor):
 
         denom=np.sum(neigh_sim, axis=1)
         for j in range(_y.shape[1]):
-            num = np.sum(_y[neigh_ind, j] * neigh_sim[j], axis=1)
+            num = np.sum(_y[neigh_ind, j] * neigh_sim, axis=1)
             y_pred[:, j] = num / denom
 
         if self._y.ndim == 1:


### PR DESCRIPTION
This is a PR stemming from the work related to hybridization & uncertainty calc of genra-py.

I noticed an issue with how the denominator/numerator is calculated, so this is the fix for it. It previously did not select the correct similarities.
The issue breaks predictions for two cases:
- `n_queries>1`
- `n_neighbors>n_outputs`

Details of the problem/demonstration are documented in the notebook I added (`notebooks/misc/example_j_index_error.ipynb`)